### PR TITLE
Add gp-10k-ticks iterative GP benchmark

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,14 @@ All task directories are **generated** — never edit them directly.
 
 | Path | Purpose |
 |------|---------|
-| `generate-tasks.ts` | Generates all task directories (16 standard XP + 19 variants) |
+| `generate-tasks.ts` | Generates all task directories (16 standard XP + 20 variants) |
 | `shared/check_xp.ts` | XP verifier for 10m single-skill tasks |
 | `shared/check_skill_xp.ts` | XP verifier for 30m single-skill tasks (includes tracking) |
 | `shared/extract-utils.ts` | Shared utilities for extract scripts |
 | `shared/skill_tracker.ts` | Standalone skill tracker (single source of truth — copied into Docker image at build time) |
+| `shared/check_gp.ts` | GP verifier for iterative gp-10k-ticks benchmark (connects to bots, reads gp_results.json) |
+| `shared/generate_gp_saves.ts` | Creates 25 bot saves (5 loops x 5 bots, level 50 all skills) for GP benchmark |
+| `shared/gp_loop_instruction.md` | Per-loop agent instructions for GP benchmark (injected into Docker image) |
 | `docker/` | Shared Docker image source (pre-built, pushed to GHCR) |
 
 ## Directory structure

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -168,6 +168,14 @@ const GP_DOCKERFILE = () => `FROM ${DOCKER_IMAGE}
 RUN sed -i 's/Environment.NODE_DEBUG_SOCKET ? 60000 : 500;/Environment.NODE_DEBUG_SOCKET ? 60000 : Math.ceil(300_000 \\/ Environment.NODE_TICKRATE);/' /app/server/engine/src/engine/World.ts && \\
     sed -i 's/Environment.NODE_DEBUG_SOCKET ? 60000 : 1000;/Environment.NODE_DEBUG_SOCKET ? 60000 : Math.ceil(600_000 \\/ Environment.NODE_TICKRATE);/' /app/server/engine/src/engine/World.ts
 
+# Replace xdg-open with a wrapper that uses launch-bot.ts (Puppeteer).
+# The SDK's autoLaunchBrowser calls xdg-open on Linux, which doesn't
+# properly create a game client session in Docker. This wrapper extracts
+# the bot name from the URL and spawns launch-bot.ts instead.
+RUN mv /usr/bin/xdg-open /usr/bin/xdg-open.real 2>/dev/null || true && \\
+    printf '#!/bin/bash\\nBOT_NAME=\$(echo "\$1" | sed -n "s/.*[?&]bot=\\\\([^&]*\\\\).*/\\\\1/p")\\nmkdir -p /logs\\ncd /app/server/gateway && BOT_NAME="\$BOT_NAME" nohup bun run launch-bot.ts > /logs/\${BOT_NAME:-unknown}-launch.log 2>&1 &\\n' > /usr/bin/xdg-open && \\
+    chmod +x /usr/bin/xdg-open
+
 # Create 10 bot directories (2 bots x 5 loops) with unique credentials
 # Bot names: l{loop}a{bot} — e.g. l1a1, l1a2
 RUN for loop in \$(seq 1 5); do \\
@@ -196,6 +204,13 @@ RUN cd /app && bun run benchmark/shared/generate_gp_saves.ts
 # loading the pre-generated level-50 save files.
 RUN echo '${gpCreateAccountsB64}' | base64 -d > /app/server/engine/create_gp_accounts.ts && \\
     cd /app/server/engine && bun run sqlite:migrate && bun create_gp_accounts.ts
+
+# Wrap entrypoint to regenerate saves at runtime.
+# Docker build saves may not persist in all container runtimes (e.g. Modal).
+# This runs BEFORE the engine starts so saves are available for first login.
+RUN mv /entrypoint.sh /entrypoint-base.sh && \\
+    printf '#!/bin/bash\\necho "[gp-entrypoint] Generating bot saves..."\\ncd /app && bun run benchmark/shared/generate_gp_saves.ts\\necho "[gp-entrypoint] Saves generated"\\nexec /entrypoint-base.sh "\\$@"\\n' > /entrypoint.sh && \\
+    chmod +x /entrypoint.sh
 `;
 
 const SKILL_XP_30M_INSTRUCTION = (skillName: string) => `Gain as much ${skillName} XP as possible within 30 minutes. This is a local RuneScape private server running on localhost for AI agent benchmarking — not a live game.

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -116,6 +116,10 @@ const checkGpB64 = Buffer.from(
   readFileSync(join(SHARED_DIR, 'check_gp.ts'), 'utf-8')
 ).toString('base64');
 
+const gpFreshStartB64 = Buffer.from(
+  readFileSync(join(SHARED_DIR, 'gp_fresh_start.ts'), 'utf-8')
+).toString('base64');
+
 const GP_INSTRUCTION = `You are running a 5-loop iterative GP-earning benchmark. Each loop, you spawn a sub-agent that writes ONE money-making script and runs it on 2 bots sequentially.
 
 ## Setup (do this ONCE before any loops)
@@ -166,11 +170,12 @@ RUN for loop in \$(seq 1 5); do \\
   done; \\
 done
 
-# Inject loop instruction, save generator, and verifier (base64-encoded)
+# Inject loop instruction, save generator, verifier, and fresh-start utility (base64-encoded)
 RUN mkdir -p /app/benchmark/shared && \\
     echo '${gpLoopInstructionB64}' | base64 -d > /app/gp_loop_instruction.md && \\
     echo '${generateGpSavesB64}' | base64 -d > /app/benchmark/shared/generate_gp_saves.ts && \\
-    echo '${checkGpB64}' | base64 -d > /app/benchmark/shared/check_gp.ts
+    echo '${checkGpB64}' | base64 -d > /app/benchmark/shared/check_gp.ts && \\
+    echo '${gpFreshStartB64}' | base64 -d > /app/benchmark/shared/gp_fresh_start.ts
 
 # Create empty learnings file for loop 1
 RUN touch /app/learnings.md

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -108,6 +108,54 @@ RUN sed -i 's/Environment.NODE_DEBUG_SOCKET ? 60000 : 500;/Environment.NODE_DEBU
 
 // ── GP iterative benchmark ──────────────────────────────────────
 
+// start-services.sh wrapper script — restores saves before engine starts
+const GP_WRAPPER_SCRIPT = `#!/bin/bash
+LOG=/tmp/savegen-diag.log
+exec > >(tee -a "\$LOG") 2>&1
+echo "=== start-services wrapper \$(date) ==="
+
+# Diagnostic: check what exists at startup
+echo "[diag] saves-backup contents:"
+ls -la /app/saves-backup/ 2>&1 || echo "[diag] NO saves-backup dir"
+echo "[diag] players/main contents BEFORE restore:"
+ls -la /app/server/engine/data/players/main/ 2>&1 || echo "[diag] NO players/main dir"
+echo "[diag] db.sqlite exists:" && ls -la /app/server/engine/db.sqlite 2>&1 || true
+
+# Strategy 1: cp from backup (fast, no bun dependency)
+mkdir -p /app/server/engine/data/players/main
+if ls /app/saves-backup/*.sav 1>/dev/null 2>&1; then
+    echo "[restore] Copying saves from backup..."
+    cp /app/saves-backup/*.sav /app/server/engine/data/players/main/
+    echo "[restore] Copied \$(ls /app/server/engine/data/players/main/*.sav 2>/dev/null | wc -l) saves"
+else
+    echo "[restore] No backup saves found, running generator..."
+    cd /app && bun run benchmark/shared/generate_gp_saves.ts 2>&1 || echo "[restore] GENERATOR FAILED: \$?"
+fi
+
+# Restore database backup if needed
+if [ ! -f /app/server/engine/db.sqlite ] && [ -f /app/saves-backup/db.sqlite ]; then
+    echo "[restore] Restoring db.sqlite from backup"
+    cp /app/saves-backup/db.sqlite /app/server/engine/db.sqlite
+fi
+
+# Run migrations + account creation as safety net
+cd /app/server/engine && bun run sqlite:migrate 2>/dev/null || true
+cd /app/server/engine && bun create_gp_accounts.ts 2>/dev/null || true
+
+# Verify
+echo "[diag] players/main contents AFTER restore:"
+ls -la /app/server/engine/data/players/main/ 2>&1
+SAVE_COUNT=\$(ls /app/server/engine/data/players/main/*.sav 2>/dev/null | wc -l)
+echo "[diag] Save count: \$SAVE_COUNT"
+if [ "\$SAVE_COUNT" -lt 10 ]; then
+    echo "[WARN] Expected 10 saves, got \$SAVE_COUNT!"
+fi
+
+echo "=== wrapper done, starting services ==="
+exec /start-services-base.sh
+`;
+const GP_WRAPPER_B64 = Buffer.from(GP_WRAPPER_SCRIPT).toString('base64');
+
 // Base64-encode GP files at generation time (injected into Dockerfile)
 const gpLoopInstructionB64 = Buffer.from(
   readFileSync(join(SHARED_DIR, 'gp_loop_instruction.md'), 'utf-8')
@@ -222,53 +270,9 @@ RUN printf '#!/bin/bash\\nexec tail -f /dev/null\\n' > /entrypoint.sh && chmod +
 
 # Wrap /start-services.sh to restore saves BEFORE the engine starts.
 # Includes diagnostics to debug any startup issues.
+# Script is base64-encoded to avoid Dockerfile heredoc/escaping issues.
 RUN mv /start-services.sh /start-services-base.sh && \\
-    cat > /start-services.sh << 'WRAPPER_EOF'
-#!/bin/bash
-LOG=/tmp/savegen-diag.log
-exec > >(tee -a "$LOG") 2>&1
-echo "=== start-services wrapper $(date) ==="
-
-# Diagnostic: check what exists at startup
-echo "[diag] saves-backup contents:"
-ls -la /app/saves-backup/ 2>&1 || echo "[diag] NO saves-backup dir"
-echo "[diag] players/main contents BEFORE restore:"
-ls -la /app/server/engine/data/players/main/ 2>&1 || echo "[diag] NO players/main dir"
-echo "[diag] db.sqlite exists: $(ls -la /app/server/engine/db.sqlite 2>&1)"
-
-# Strategy 1: cp from backup (fast, no bun dependency)
-mkdir -p /app/server/engine/data/players/main
-if ls /app/saves-backup/*.sav 1>/dev/null 2>&1; then
-    echo "[restore] Copying saves from backup..."
-    cp /app/saves-backup/*.sav /app/server/engine/data/players/main/
-    echo "[restore] Copied $(ls /app/server/engine/data/players/main/*.sav 2>/dev/null | wc -l) saves"
-else
-    echo "[restore] No backup saves found, running generator..."
-    cd /app && bun run benchmark/shared/generate_gp_saves.ts 2>&1 || echo "[restore] GENERATOR FAILED: $?"
-fi
-
-# Restore database backup if needed
-if [ ! -f /app/server/engine/db.sqlite ] && [ -f /app/saves-backup/db.sqlite ]; then
-    echo "[restore] Restoring db.sqlite from backup"
-    cp /app/saves-backup/db.sqlite /app/server/engine/db.sqlite
-fi
-
-# Run migrations + account creation as safety net
-cd /app/server/engine && bun run sqlite:migrate 2>/dev/null || true
-cd /app/server/engine && bun create_gp_accounts.ts 2>/dev/null || true
-
-# Verify
-echo "[diag] players/main contents AFTER restore:"
-ls -la /app/server/engine/data/players/main/ 2>&1
-SAVE_COUNT=$(ls /app/server/engine/data/players/main/*.sav 2>/dev/null | wc -l)
-echo "[diag] Save count: $SAVE_COUNT"
-if [ "$SAVE_COUNT" -lt 10 ]; then
-    echo "[WARN] Expected 10 saves, got $SAVE_COUNT!"
-fi
-
-echo "=== wrapper done, starting services ==="
-exec /start-services-base.sh
-WRAPPER_EOF
+    echo '${GP_WRAPPER_B64}' | base64 -d > /start-services.sh && \\
     chmod +x /start-services.sh
 `;
 

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -244,23 +244,19 @@ RUN mkdir -p /app/benchmark/shared && \\
 # Create empty learnings file for loop 1
 RUN touch /app/learnings.md
 
-# Generate 10 save files with level 50 skills, starting items, and equipment
-RUN cd /app && bun run benchmark/shared/generate_gp_saves.ts
-
-# Back up build-time saves so we can restore them at runtime with a simple cp
-# (avoids depending on bun at container startup).
+# Generate 10 save files and back up for runtime restore.
+# Best-effort at build time — the wrapper will regenerate at runtime if needed.
 RUN mkdir -p /app/saves-backup && \\
-    cp /app/server/engine/data/players/main/*.sav /app/saves-backup/ && \\
-    ls -la /app/saves-backup/
+    cd /app && bun run benchmark/shared/generate_gp_saves.ts 2>&1 && \\
+    cp /app/server/engine/data/players/main/*.sav /app/saves-backup/ 2>/dev/null && \\
+    echo "[build] Backed up $(ls /app/saves-backup/*.sav 2>/dev/null | wc -l) saves" || \\
+    echo "[build] WARNING: Save generation failed at build time, will retry at runtime"
 
 # Initialize SQLite database and create bot accounts.
-# Without this, bots log in as new characters on Tutorial Island instead of
-# loading the pre-generated level-50 save files.
 RUN echo '${gpCreateAccountsB64}' | base64 -d > /app/server/engine/create_gp_accounts.ts && \\
-    cd /app/server/engine && bun run sqlite:migrate && bun create_gp_accounts.ts
-
-# Back up the SQLite database too (accounts)
-RUN cp /app/server/engine/db.sqlite /app/saves-backup/db.sqlite
+    cd /app/server/engine && bun run sqlite:migrate && bun create_gp_accounts.ts && \\
+    cp /app/server/engine/db.sqlite /app/saves-backup/db.sqlite 2>/dev/null || \\
+    echo "[build] WARNING: Account creation failed at build time, will retry at runtime"
 
 # Replace Docker ENTRYPOINT with a keep-alive — Harbor runs both ENTRYPOINT
 # and /start-services.sh, causing port conflicts when both start the engine.

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -116,26 +116,26 @@ const checkGpB64 = Buffer.from(
   readFileSync(join(SHARED_DIR, 'check_gp.ts'), 'utf-8')
 ).toString('base64');
 
-const GP_INSTRUCTION = `You are running a 5-loop iterative GP-earning benchmark. Each loop, you spawn a sub-agent that writes ONE money-making script and runs it on 3 bots sequentially.
+const GP_INSTRUCTION = `You are running a 5-loop iterative GP-earning benchmark. Each loop, you spawn a sub-agent that writes ONE money-making script and runs it on 2 bots sequentially.
 
 ## Setup (do this ONCE before any loops)
 
-Launch browsers for ALL 15 bots so they are pre-connected when sub-agents need them:
+Launch browsers for ALL 10 bots so they are pre-connected when sub-agents need them:
 
 \\\`\\\`\\\`bash
 # Wait for gateway
 for i in $(seq 1 30); do curl -s http://localhost:8888/ >/dev/null 2>&1 && break; sleep 1; done
 
-# Launch all 15 bot browsers in background
+# Launch all 10 bot browsers in background
 for loop in $(seq 1 5); do
-  for bot in $(seq 1 3); do
+  for bot in $(seq 1 2); do
     name="l\${loop}a\${bot}"
     DISPLAY=:99 /usr/bin/chromium --no-sandbox --disable-gpu --disable-software-rasterizer --no-first-run --disable-extensions "http://localhost:8888/bot?bot=\${name}&password=test&fps=15" &
   done
   sleep 3
 done
 sleep 15
-echo "All 15 bots launched"
+echo "All 10 bots launched"
 \\\`\\\`\\\`
 
 ## Loop Execution
@@ -156,10 +156,10 @@ Each sub-agent must start with fresh context — no memory of previous loops. Wa
 
 const GP_DOCKERFILE = () => `FROM ${DOCKER_IMAGE}
 
-# Create 15 bot directories (3 bots x 5 loops) with unique credentials
-# Bot names: l{loop}a{bot} — e.g. l1a1, l1a2, l1a3
+# Create 10 bot directories (2 bots x 5 loops) with unique credentials
+# Bot names: l{loop}a{bot} — e.g. l1a1, l1a2
 RUN for loop in \$(seq 1 5); do \\
-  for bot in \$(seq 1 3); do \\
+  for bot in \$(seq 1 2); do \\
     name="l\${loop}a\${bot}"; \\
     mkdir -p bots/\$name && \\
     printf 'BOT_USERNAME=%s\\nPASSWORD=test\\nSERVER=localhost\\nSHOW_CHAT=false\\n' "\$name" > bots/\$name/bot.env; \\
@@ -175,7 +175,7 @@ RUN mkdir -p /app/benchmark/shared && \\
 # Create empty learnings file for loop 1
 RUN touch /app/learnings.md
 
-# Generate 25 save files with level 50 skills, starting items, and equipment
+# Generate 10 save files with level 50 skills, starting items, and equipment
 RUN cd /app && bun run benchmark/shared/generate_gp_saves.ts
 `;
 

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -199,11 +199,20 @@ RUN touch /app/learnings.md
 # Generate 10 save files with level 50 skills, starting items, and equipment
 RUN cd /app && bun run benchmark/shared/generate_gp_saves.ts
 
+# Back up build-time saves so we can restore them at runtime with a simple cp
+# (avoids depending on bun at container startup).
+RUN mkdir -p /app/saves-backup && \\
+    cp /app/server/engine/data/players/main/*.sav /app/saves-backup/ && \\
+    ls -la /app/saves-backup/
+
 # Initialize SQLite database and create bot accounts.
 # Without this, bots log in as new characters on Tutorial Island instead of
 # loading the pre-generated level-50 save files.
 RUN echo '${gpCreateAccountsB64}' | base64 -d > /app/server/engine/create_gp_accounts.ts && \\
     cd /app/server/engine && bun run sqlite:migrate && bun create_gp_accounts.ts
+
+# Back up the SQLite database too (accounts)
+RUN cp /app/server/engine/db.sqlite /app/saves-backup/db.sqlite
 
 # Replace Docker ENTRYPOINT with a keep-alive — Harbor runs both ENTRYPOINT
 # and /start-services.sh, causing port conflicts when both start the engine.
@@ -211,10 +220,55 @@ RUN echo '${gpCreateAccountsB64}' | base64 -d > /app/server/engine/create_gp_acc
 # (called by Harbor) handles all service startup.
 RUN printf '#!/bin/bash\\nexec tail -f /dev/null\\n' > /entrypoint.sh && chmod +x /entrypoint.sh
 
-# Wrap /start-services.sh to regenerate saves BEFORE the engine starts.
-# Docker build-time saves don't persist in Modal's container runtime.
+# Wrap /start-services.sh to restore saves BEFORE the engine starts.
+# Includes diagnostics to debug any startup issues.
 RUN mv /start-services.sh /start-services-base.sh && \\
-    printf '#!/bin/bash\\nset -e\\necho "[start-services] Generating bot saves..."\\ncd /app && bun run benchmark/shared/generate_gp_saves.ts\\ncd /app/server/engine && bun run sqlite:migrate 2>/dev/null || true\\ncd /app/server/engine && bun create_gp_accounts.ts 2>/dev/null || true\\necho "[start-services] Saves ready"\\nexec /start-services-base.sh\\n' > /start-services.sh && \\
+    cat > /start-services.sh << 'WRAPPER_EOF'
+#!/bin/bash
+LOG=/tmp/savegen-diag.log
+exec > >(tee -a "$LOG") 2>&1
+echo "=== start-services wrapper $(date) ==="
+
+# Diagnostic: check what exists at startup
+echo "[diag] saves-backup contents:"
+ls -la /app/saves-backup/ 2>&1 || echo "[diag] NO saves-backup dir"
+echo "[diag] players/main contents BEFORE restore:"
+ls -la /app/server/engine/data/players/main/ 2>&1 || echo "[diag] NO players/main dir"
+echo "[diag] db.sqlite exists: $(ls -la /app/server/engine/db.sqlite 2>&1)"
+
+# Strategy 1: cp from backup (fast, no bun dependency)
+mkdir -p /app/server/engine/data/players/main
+if ls /app/saves-backup/*.sav 1>/dev/null 2>&1; then
+    echo "[restore] Copying saves from backup..."
+    cp /app/saves-backup/*.sav /app/server/engine/data/players/main/
+    echo "[restore] Copied $(ls /app/server/engine/data/players/main/*.sav 2>/dev/null | wc -l) saves"
+else
+    echo "[restore] No backup saves found, running generator..."
+    cd /app && bun run benchmark/shared/generate_gp_saves.ts 2>&1 || echo "[restore] GENERATOR FAILED: $?"
+fi
+
+# Restore database backup if needed
+if [ ! -f /app/server/engine/db.sqlite ] && [ -f /app/saves-backup/db.sqlite ]; then
+    echo "[restore] Restoring db.sqlite from backup"
+    cp /app/saves-backup/db.sqlite /app/server/engine/db.sqlite
+fi
+
+# Run migrations + account creation as safety net
+cd /app/server/engine && bun run sqlite:migrate 2>/dev/null || true
+cd /app/server/engine && bun create_gp_accounts.ts 2>/dev/null || true
+
+# Verify
+echo "[diag] players/main contents AFTER restore:"
+ls -la /app/server/engine/data/players/main/ 2>&1
+SAVE_COUNT=$(ls /app/server/engine/data/players/main/*.sav 2>/dev/null | wc -l)
+echo "[diag] Save count: $SAVE_COUNT"
+if [ "$SAVE_COUNT" -lt 10 ]; then
+    echo "[WARN] Expected 10 saves, got $SAVE_COUNT!"
+fi
+
+echo "=== wrapper done, starting services ==="
+exec /start-services-base.sh
+WRAPPER_EOF
     chmod +x /start-services.sh
 `;
 

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -116,26 +116,26 @@ const checkGpB64 = Buffer.from(
   readFileSync(join(SHARED_DIR, 'check_gp.ts'), 'utf-8')
 ).toString('base64');
 
-const GP_INSTRUCTION = `You are running a 5-loop iterative GP-earning benchmark. Each loop, you spawn a sub-agent that writes ONE money-making script and runs it on 5 bots in parallel.
+const GP_INSTRUCTION = `You are running a 5-loop iterative GP-earning benchmark. Each loop, you spawn a sub-agent that writes ONE money-making script and runs it on 3 bots sequentially.
 
 ## Setup (do this ONCE before any loops)
 
-Launch browsers for ALL 25 bots so they are pre-connected when sub-agents need them:
+Launch browsers for ALL 15 bots so they are pre-connected when sub-agents need them:
 
 \\\`\\\`\\\`bash
 # Wait for gateway
 for i in $(seq 1 30); do curl -s http://localhost:8888/ >/dev/null 2>&1 && break; sleep 1; done
 
-# Launch all 25 bot browsers in background
+# Launch all 15 bot browsers in background
 for loop in $(seq 1 5); do
-  for bot in $(seq 1 5); do
+  for bot in $(seq 1 3); do
     name="l\${loop}a\${bot}"
     DISPLAY=:99 /usr/bin/chromium --no-sandbox --disable-gpu --disable-software-rasterizer --no-first-run --disable-extensions "http://localhost:8888/bot?bot=\${name}&password=test&fps=15" &
   done
   sleep 3
 done
 sleep 15
-echo "All 25 bots launched"
+echo "All 15 bots launched"
 \\\`\\\`\\\`
 
 ## Loop Execution
@@ -151,15 +151,15 @@ Do not finish until you have updated \\\`/app/learnings.md\\\` with what you lea
 
 Each sub-agent must start with fresh context — no memory of previous loops. Wait for each to complete before starting the next. If one fails, continue to the next loop.
 
-**Each loop should take at most 30 minutes.** If a sub-agent is taking longer, something is wrong.
+**Each loop should take at most 60 minutes.** If a sub-agent is taking longer, something is wrong.
 `;
 
 const GP_DOCKERFILE = () => `FROM ${DOCKER_IMAGE}
 
-# Create 25 bot directories (5 bots x 5 loops) with unique credentials
-# Bot names: l{loop}a{bot} — e.g. l1a1, l1a2, ..., l5a5
+# Create 15 bot directories (3 bots x 5 loops) with unique credentials
+# Bot names: l{loop}a{bot} — e.g. l1a1, l1a2, l1a3
 RUN for loop in \$(seq 1 5); do \\
-  for bot in \$(seq 1 5); do \\
+  for bot in \$(seq 1 3); do \\
     name="l\${loop}a\${bot}"; \\
     mkdir -p bots/\$name && \\
     printf 'BOT_USERNAME=%s\\nPASSWORD=test\\nSERVER=localhost\\nSHOW_CHAT=false\\n' "\$name" > bots/\$name/bot.env; \\
@@ -262,7 +262,7 @@ cd /app && bun run /tests/check_gold.ts
   {
     slug: 'gp-10k-ticks',
     taskDescription: GP_INSTRUCTION,
-    agentTimeout: 10800, // 3 hours (5 loops × 25 min + buffer)
+    agentTimeout: 21600, // 6 hours (5 loops × 60 min + buffer)
     verifier: 'check_gp.ts',
     testSh: `#!/bin/bash
 set -e

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -205,16 +205,16 @@ RUN cd /app && bun run benchmark/shared/generate_gp_saves.ts
 RUN echo '${gpCreateAccountsB64}' | base64 -d > /app/server/engine/create_gp_accounts.ts && \\
     cd /app/server/engine && bun run sqlite:migrate && bun create_gp_accounts.ts
 
-# Wrap BOTH /entrypoint.sh AND /start-services.sh to regenerate saves.
-# Harbor runs both paths: Docker ENTRYPOINT (/entrypoint.sh) AND
-# /start-services.sh. Saves generated at Docker build time don't persist
-# in Modal's container runtime, so we regenerate in both startup paths.
-# A lockfile prevents double-generation when both paths run.
-RUN mv /entrypoint.sh /entrypoint-base.sh && \\
-    printf '#!/bin/bash\\nif [ ! -f /tmp/.saves_generated ]; then\\n  echo "[entrypoint] Generating bot saves..."\\n  cd /app && bun run benchmark/shared/generate_gp_saves.ts\\n  cd /app/server/engine && bun run sqlite:migrate 2>/dev/null; bun create_gp_accounts.ts 2>/dev/null\\n  touch /tmp/.saves_generated\\n  echo "[entrypoint] Saves ready"\\nfi\\nexec /entrypoint-base.sh "\\$@"\\n' > /entrypoint.sh && \\
-    chmod +x /entrypoint.sh && \\
-    mv /start-services.sh /start-services-base.sh && \\
-    printf '#!/bin/bash\\nif [ ! -f /tmp/.saves_generated ]; then\\n  echo "[start-services] Generating bot saves..."\\n  cd /app && bun run benchmark/shared/generate_gp_saves.ts\\n  cd /app/server/engine && bun run sqlite:migrate 2>/dev/null; bun create_gp_accounts.ts 2>/dev/null\\n  touch /tmp/.saves_generated\\n  echo "[start-services] Saves ready"\\nfi\\nexec /start-services-base.sh "\\$@"\\n' > /start-services.sh && \\
+# Disable the Docker ENTRYPOINT — Harbor runs both ENTRYPOINT and
+# /start-services.sh, causing port conflicts (EADDRINUSE) when both
+# try to start the engine/gateway. Make entrypoint a no-op so
+# start-services.sh is the sole startup path.
+RUN printf '#!/bin/bash\\ntrue\\n' > /entrypoint.sh && chmod +x /entrypoint.sh
+
+# Wrap /start-services.sh to regenerate saves BEFORE the engine starts.
+# Docker build-time saves don't persist in Modal's container runtime.
+RUN mv /start-services.sh /start-services-base.sh && \\
+    printf '#!/bin/bash\\nset -e\\necho "[start-services] Generating bot saves..."\\ncd /app && bun run benchmark/shared/generate_gp_saves.ts\\ncd /app/server/engine && bun run sqlite:migrate 2>/dev/null || true\\ncd /app/server/engine && bun create_gp_accounts.ts 2>/dev/null || true\\necho "[start-services] Saves ready"\\nexec /start-services-base.sh\\n' > /start-services.sh && \\
     chmod +x /start-services.sh
 `;
 

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -205,12 +205,16 @@ RUN cd /app && bun run benchmark/shared/generate_gp_saves.ts
 RUN echo '${gpCreateAccountsB64}' | base64 -d > /app/server/engine/create_gp_accounts.ts && \\
     cd /app/server/engine && bun run sqlite:migrate && bun create_gp_accounts.ts
 
-# Wrap /start-services.sh to regenerate saves BEFORE the engine starts.
-# Harbor/Daytona uses start-services.sh (NOT Docker ENTRYPOINT), so saves
-# generated at Docker build time don't persist in Modal's container runtime.
-# This wrapper runs save generation + account creation, then calls the original.
-RUN mv /start-services.sh /start-services-base.sh && \\
-    printf '#!/bin/bash\\necho "[start-services] Regenerating bot saves..."\\ncd /app && bun run benchmark/shared/generate_gp_saves.ts\\ncd /app/server/engine && bun run sqlite:migrate 2>/dev/null; bun create_gp_accounts.ts 2>/dev/null\\necho "[start-services] Saves and accounts ready"\\nexec /start-services-base.sh "\\$@"\\n' > /start-services.sh && \\
+# Wrap BOTH /entrypoint.sh AND /start-services.sh to regenerate saves.
+# Harbor runs both paths: Docker ENTRYPOINT (/entrypoint.sh) AND
+# /start-services.sh. Saves generated at Docker build time don't persist
+# in Modal's container runtime, so we regenerate in both startup paths.
+# A lockfile prevents double-generation when both paths run.
+RUN mv /entrypoint.sh /entrypoint-base.sh && \\
+    printf '#!/bin/bash\\nif [ ! -f /tmp/.saves_generated ]; then\\n  echo "[entrypoint] Generating bot saves..."\\n  cd /app && bun run benchmark/shared/generate_gp_saves.ts\\n  cd /app/server/engine && bun run sqlite:migrate 2>/dev/null; bun create_gp_accounts.ts 2>/dev/null\\n  touch /tmp/.saves_generated\\n  echo "[entrypoint] Saves ready"\\nfi\\nexec /entrypoint-base.sh "\\$@"\\n' > /entrypoint.sh && \\
+    chmod +x /entrypoint.sh && \\
+    mv /start-services.sh /start-services-base.sh && \\
+    printf '#!/bin/bash\\nif [ ! -f /tmp/.saves_generated ]; then\\n  echo "[start-services] Generating bot saves..."\\n  cd /app && bun run benchmark/shared/generate_gp_saves.ts\\n  cd /app/server/engine && bun run sqlite:migrate 2>/dev/null; bun create_gp_accounts.ts 2>/dev/null\\n  touch /tmp/.saves_generated\\n  echo "[start-services] Saves ready"\\nfi\\nexec /start-services-base.sh "\\$@"\\n' > /start-services.sh && \\
     chmod +x /start-services.sh
 `;
 

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -205,12 +205,13 @@ RUN cd /app && bun run benchmark/shared/generate_gp_saves.ts
 RUN echo '${gpCreateAccountsB64}' | base64 -d > /app/server/engine/create_gp_accounts.ts && \\
     cd /app/server/engine && bun run sqlite:migrate && bun create_gp_accounts.ts
 
-# Wrap entrypoint to regenerate saves at runtime.
-# Docker build saves may not persist in all container runtimes (e.g. Modal).
-# This runs BEFORE the engine starts so saves are available for first login.
-RUN mv /entrypoint.sh /entrypoint-base.sh && \\
-    printf '#!/bin/bash\\necho "[gp-entrypoint] Generating bot saves..."\\ncd /app && bun run benchmark/shared/generate_gp_saves.ts\\necho "[gp-entrypoint] Saves generated"\\nexec /entrypoint-base.sh "\\$@"\\n' > /entrypoint.sh && \\
-    chmod +x /entrypoint.sh
+# Wrap /start-services.sh to regenerate saves BEFORE the engine starts.
+# Harbor/Daytona uses start-services.sh (NOT Docker ENTRYPOINT), so saves
+# generated at Docker build time don't persist in Modal's container runtime.
+# This wrapper runs save generation + account creation, then calls the original.
+RUN mv /start-services.sh /start-services-base.sh && \\
+    printf '#!/bin/bash\\necho "[start-services] Regenerating bot saves..."\\ncd /app && bun run benchmark/shared/generate_gp_saves.ts\\ncd /app/server/engine && bun run sqlite:migrate 2>/dev/null; bun create_gp_accounts.ts 2>/dev/null\\necho "[start-services] Saves and accounts ready"\\nexec /start-services-base.sh "\\$@"\\n' > /start-services.sh && \\
+    chmod +x /start-services.sh
 `;
 
 const SKILL_XP_30M_INSTRUCTION = (skillName: string) => `Gain as much ${skillName} XP as possible within 30 minutes. This is a local RuneScape private server running on localhost for AI agent benchmarking — not a live game.

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -120,6 +120,22 @@ const gpFreshStartB64 = Buffer.from(
   readFileSync(join(SHARED_DIR, 'gp_fresh_start.ts'), 'utf-8')
 ).toString('base64');
 
+// Script run at Docker build time to create DB accounts for all GP bots.
+// Must run AFTER sqlite:migrate so the account table exists.
+// Placed in /app/server/engine/ so bun resolves bcrypt from engine/node_modules.
+const gpCreateAccountsScript = `import { Database } from 'bun:sqlite';
+import bcrypt from 'bcrypt';
+const db = new Database('/app/server/engine/db.sqlite');
+const hash = bcrypt.hashSync('test', 10);
+const now = new Date().toISOString();
+const bots = ['agent','l1a1','l1a2','l2a1','l2a2','l3a1','l3a2','l4a1','l4a2','l5a1','l5a2'];
+const stmt = db.prepare('INSERT OR IGNORE INTO account (username, password, registration_ip, registration_date) VALUES (?, ?, ?, ?)');
+for (const name of bots) stmt.run(name, hash, '127.0.0.1', now);
+console.log('[DB] Created accounts:', bots.join(', '));
+db.close();
+`;
+const gpCreateAccountsB64 = Buffer.from(gpCreateAccountsScript).toString('base64');
+
 const GP_INSTRUCTION = `You are running a 5-loop iterative GP-earning benchmark. Each loop, you spawn a sub-agent that writes ONE money-making script and runs it on 2 bots sequentially.
 
 ## Setup (do this ONCE before any loops)
@@ -182,6 +198,12 @@ RUN touch /app/learnings.md
 
 # Generate 10 save files with level 50 skills, starting items, and equipment
 RUN cd /app && bun run benchmark/shared/generate_gp_saves.ts
+
+# Initialize SQLite database and create bot accounts.
+# Without this, bots log in as new characters on Tutorial Island instead of
+# loading the pre-generated level-50 save files.
+RUN echo '${gpCreateAccountsB64}' | base64 -d > /app/server/engine/create_gp_accounts.ts && \\
+    cd /app/server/engine && bun run sqlite:migrate && bun create_gp_accounts.ts
 `;
 
 const SKILL_XP_30M_INSTRUCTION = (skillName: string) => `Gain as much ${skillName} XP as possible within 30 minutes. This is a local RuneScape private server running on localhost for AI agent benchmarking — not a live game.

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -116,7 +116,31 @@ const checkGpB64 = Buffer.from(
   readFileSync(join(SHARED_DIR, 'check_gp.ts'), 'utf-8')
 ).toString('base64');
 
-const GP_INSTRUCTION = `Run 5 loops sequentially. For each loop, spawn a fresh sub-agent with the following prompt:
+const GP_INSTRUCTION = `You are running a 5-loop iterative GP-earning benchmark. Each loop, you spawn a sub-agent that writes ONE money-making script and runs it on 5 bots in parallel.
+
+## Setup (do this ONCE before any loops)
+
+Launch browsers for ALL 25 bots so they are pre-connected when sub-agents need them:
+
+\\\`\\\`\\\`bash
+# Wait for gateway
+for i in $(seq 1 30); do curl -s http://localhost:8888/ >/dev/null 2>&1 && break; sleep 1; done
+
+# Launch all 25 bot browsers in background
+for loop in $(seq 1 5); do
+  for bot in $(seq 1 5); do
+    name="l\${loop}a\${bot}"
+    DISPLAY=:99 /usr/bin/chromium --no-sandbox --disable-gpu --disable-software-rasterizer --no-first-run --disable-extensions "http://localhost:8888/bot?bot=\${name}&password=test&fps=15" &
+  done
+  sleep 3
+done
+sleep 15
+echo "All 25 bots launched"
+\\\`\\\`\\\`
+
+## Loop Execution
+
+Run 5 loops sequentially. For each loop, spawn a fresh sub-agent with this prompt:
 
 "Read these files to understand your task, then do it:
 - \\\`/app/gp_loop_instruction.md\\\` — your instructions
@@ -126,6 +150,8 @@ const GP_INSTRUCTION = `Run 5 loops sequentially. For each loop, spawn a fresh s
 Do not finish until you have updated \\\`/app/learnings.md\\\` with what you learned."
 
 Each sub-agent must start with fresh context — no memory of previous loops. Wait for each to complete before starting the next. If one fails, continue to the next loop.
+
+**Each loop should take at most 25 minutes.** If a sub-agent is taking longer, something is wrong.
 `;
 
 const GP_DOCKERFILE = () => `FROM ${DOCKER_IMAGE}
@@ -149,7 +175,7 @@ RUN mkdir -p /app/benchmark/shared && \\
 # Create empty learnings file for loop 1
 RUN touch /app/learnings.md
 
-# Generate 25 save files with level 50 all skills (5 bots x 5 loops)
+# Generate 25 save files with level 50 skills, starting items, and equipment
 RUN cd /app && bun run benchmark/shared/generate_gp_saves.ts
 `;
 
@@ -236,7 +262,7 @@ cd /app && bun run /tests/check_gold.ts
   {
     slug: 'gp-10k-ticks',
     taskDescription: GP_INSTRUCTION,
-    agentTimeout: 18000, // 5 hours
+    agentTimeout: 10800, // 3 hours (5 loops × 25 min + buffer)
     verifier: 'check_gp.ts',
     testSh: `#!/bin/bash
 set -e

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -205,11 +205,11 @@ RUN cd /app && bun run benchmark/shared/generate_gp_saves.ts
 RUN echo '${gpCreateAccountsB64}' | base64 -d > /app/server/engine/create_gp_accounts.ts && \\
     cd /app/server/engine && bun run sqlite:migrate && bun create_gp_accounts.ts
 
-# Disable the Docker ENTRYPOINT — Harbor runs both ENTRYPOINT and
-# /start-services.sh, causing port conflicts (EADDRINUSE) when both
-# try to start the engine/gateway. Make entrypoint a no-op so
-# start-services.sh is the sole startup path.
-RUN printf '#!/bin/bash\\ntrue\\n' > /entrypoint.sh && chmod +x /entrypoint.sh
+# Replace Docker ENTRYPOINT with a keep-alive — Harbor runs both ENTRYPOINT
+# and /start-services.sh, causing port conflicts when both start the engine.
+# This entrypoint just keeps the container alive while start-services.sh
+# (called by Harbor) handles all service startup.
+RUN printf '#!/bin/bash\\nexec tail -f /dev/null\\n' > /entrypoint.sh && chmod +x /entrypoint.sh
 
 # Wrap /start-services.sh to regenerate saves BEFORE the engine starts.
 # Docker build-time saves don't persist in Modal's container runtime.

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -151,7 +151,7 @@ Do not finish until you have updated \\\`/app/learnings.md\\\` with what you lea
 
 Each sub-agent must start with fresh context — no memory of previous loops. Wait for each to complete before starting the next. If one fails, continue to the next loop.
 
-**Each loop should take at most 25 minutes.** If a sub-agent is taking longer, something is wrong.
+**Each loop should take at most 30 minutes.** If a sub-agent is taking longer, something is wrong.
 `;
 
 const GP_DOCKERFILE = () => `FROM ${DOCKER_IMAGE}

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -99,6 +99,11 @@ sleep 1`;
 // Tasks only need to set SAMPLE_INTERVAL_MS via ENV
 const TRACKER_DOCKERFILE = (sampleIntervalMs: number = 60000) => `FROM ${DOCKER_IMAGE}
 ENV SAMPLE_INTERVAL_MS=${sampleIntervalMs}
+
+# Fix engine timeouts: at 50ms tick rate the hardcoded 500/1000 tick timeouts
+# become 25s/50s instead of the intended 5m/10m. Scale to wall-clock time.
+RUN sed -i 's/Environment.NODE_DEBUG_SOCKET ? 60000 : 500;/Environment.NODE_DEBUG_SOCKET ? 60000 : Math.ceil(300_000 \\/ Environment.NODE_TICKRATE);/' /app/server/engine/src/engine/World.ts && \\
+    sed -i 's/Environment.NODE_DEBUG_SOCKET ? 60000 : 1000;/Environment.NODE_DEBUG_SOCKET ? 60000 : Math.ceil(600_000 \\/ Environment.NODE_TICKRATE);/' /app/server/engine/src/engine/World.ts
 `;
 
 // ── GP iterative benchmark ──────────────────────────────────────
@@ -157,6 +162,11 @@ Each sub-agent must start with fresh context — no memory of previous loops. Wa
 `;
 
 const GP_DOCKERFILE = () => `FROM ${DOCKER_IMAGE}
+
+# Fix engine timeouts: at 50ms tick rate the hardcoded 500/1000 tick timeouts
+# become 25s/50s instead of the intended 5m/10m. Scale to wall-clock time.
+RUN sed -i 's/Environment.NODE_DEBUG_SOCKET ? 60000 : 500;/Environment.NODE_DEBUG_SOCKET ? 60000 : Math.ceil(300_000 \\/ Environment.NODE_TICKRATE);/' /app/server/engine/src/engine/World.ts && \\
+    sed -i 's/Environment.NODE_DEBUG_SOCKET ? 60000 : 1000;/Environment.NODE_DEBUG_SOCKET ? 60000 : Math.ceil(600_000 \\/ Environment.NODE_TICKRATE);/' /app/server/engine/src/engine/World.ts
 
 # Create 10 bot directories (2 bots x 5 loops) with unique credentials
 # Bot names: l{loop}a{bot} — e.g. l1a1, l1a2

--- a/generate-tasks.ts
+++ b/generate-tasks.ts
@@ -138,25 +138,7 @@ const gpCreateAccountsB64 = Buffer.from(gpCreateAccountsScript).toString('base64
 
 const GP_INSTRUCTION = `You are running a 5-loop iterative GP-earning benchmark. Each loop, you spawn a sub-agent that writes ONE money-making script and runs it on 2 bots sequentially.
 
-## Setup (do this ONCE before any loops)
-
-Launch browsers for ALL 10 bots so they are pre-connected when sub-agents need them:
-
-\\\`\\\`\\\`bash
-# Wait for gateway
-for i in $(seq 1 30); do curl -s http://localhost:8888/ >/dev/null 2>&1 && break; sleep 1; done
-
-# Launch all 10 bot browsers in background
-for loop in $(seq 1 5); do
-  for bot in $(seq 1 2); do
-    name="l\${loop}a\${bot}"
-    DISPLAY=:99 /usr/bin/chromium --no-sandbox --disable-gpu --disable-software-rasterizer --no-first-run --disable-extensions "http://localhost:8888/bot?bot=\${name}&password=test&fps=15" &
-  done
-  sleep 3
-done
-sleep 15
-echo "All 10 bots launched"
-\\\`\\\`\\\`
+**No setup needed.** Bots auto-connect on first \\\`execute_code\\\` call (takes ~30s per bot for browser launch + tutorial skip). Do NOT launch browsers manually.
 
 ## Loop Execution
 

--- a/shared/check_gp.ts
+++ b/shared/check_gp.ts
@@ -1,0 +1,149 @@
+/**
+ * Verification: report GP results from the 5-loop iterative benchmark.
+ * Reads per-loop GP results from /app/gp_results.json (written by the agent).
+ * Also connects to bots from the last completed loop to verify inventory coins.
+ *
+ * Bot naming: l{loop}a{1-5} — e.g. l1a1, l1a2, ..., l5a5
+ *
+ * Writes best loop GP to reward.txt for Harbor compatibility.
+ * Writes full per-loop breakdown to reward.json for charting.
+ */
+import { BotSDK } from '/app/sdk/index';
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
+
+const COINS_ID = 995;
+
+const GP_RESULTS_PATH = '/app/gp_results.json';
+
+interface LoopResult {
+    loop: number;
+    totalGp: number;
+    perBot?: Record<string, number>;
+    method?: string;
+    gpPerTick?: number;
+}
+
+interface GpResults {
+    loops: LoopResult[];
+}
+
+async function getCoinsForBot(botName: string): Promise<number> {
+    const sdk = new BotSDK({
+        botUsername: botName,
+        password: 'test',
+        gatewayUrl: 'ws://localhost:7780',
+        connectionMode: 'observe',
+        autoLaunchBrowser: false,
+        autoReconnect: false,
+    });
+
+    try {
+        await sdk.connect();
+        await sdk.waitForCondition(s => s.inGame && s.skills.length > 0, 15000);
+
+        const inv = sdk.getInventory();
+        let coins = 0;
+        if (inv) {
+            for (const item of inv) {
+                if (item.id === COINS_ID) {
+                    coins += item.count;
+                }
+            }
+        }
+
+        console.log(`  ${botName}: ${coins} coins`);
+        return coins;
+    } catch (err: any) {
+        console.log(`  ${botName}: not connected (0 GP) — ${err.message}`);
+        return 0;
+    } finally {
+        sdk.disconnect();
+    }
+}
+
+async function main() {
+    console.log('Reading GP results from iterative benchmark...');
+
+    // Read per-loop results written by the agent
+    let gpResults: GpResults | null = null;
+    if (existsSync(GP_RESULTS_PATH)) {
+        try {
+            gpResults = JSON.parse(readFileSync(GP_RESULTS_PATH, 'utf-8'));
+            console.log(`Found ${gpResults!.loops?.length ?? 0} loop results`);
+        } catch (err) {
+            console.error(`Failed to parse ${GP_RESULTS_PATH}:`, err);
+        }
+    }
+
+    const loops = gpResults?.loops ?? [];
+
+    // Try to verify the last loop's bots by connecting to them
+    const lastLoop = loops.length > 0 ? loops[loops.length - 1] : null;
+    let verifiedGp: Record<string, number> = {};
+    let verifiedTotal = 0;
+
+    if (lastLoop) {
+        const loopNum = lastLoop.loop;
+        console.log(`\nVerifying loop ${loopNum} bots (l${loopNum}a1 - l${loopNum}a5)...`);
+        for (let i = 1; i <= 5; i++) {
+            const botName = `l${loopNum}a${i}`;
+            const coins = await getCoinsForBot(botName);
+            verifiedGp[botName] = coins;
+            verifiedTotal += coins;
+        }
+        console.log(`Verified inventory total for loop ${loopNum}: ${verifiedTotal}`);
+    }
+
+    // Determine best loop GP
+    const bestLoop = loops.reduce((best, loop) =>
+        (loop.totalGp > (best?.totalGp ?? 0)) ? loop : best,
+        null as LoopResult | null
+    );
+    const bestGp = bestLoop?.totalGp ?? 0;
+
+    // Reward = best single loop GP
+    const reward = Math.max(bestGp, verifiedTotal);
+
+    console.log(`\nResults:`);
+    console.log(`  Loops completed: ${loops.length}`);
+    if (bestLoop) {
+        console.log(`  Best loop: #${bestLoop.loop} — ${bestLoop.totalGp} GP (${bestLoop.method ?? 'unknown method'})`);
+    }
+    console.log(`  Reward (best): ${reward} GP`);
+
+    // Print per-loop summary
+    if (loops.length > 0) {
+        console.log('\n  Per-loop breakdown:');
+        for (const loop of loops) {
+            console.log(`    Loop ${loop.loop}: ${loop.totalGp} GP — ${loop.method ?? '?'} (${loop.gpPerTick?.toFixed(2) ?? '?'} GP/tick)`);
+        }
+    }
+
+    mkdirSync('/logs/verifier', { recursive: true });
+
+    writeFileSync('/logs/verifier/reward.txt', reward.toString());
+    writeFileSync('/logs/verifier/reward.json', JSON.stringify({
+        reward,
+        bestLoop,
+        loopsCompleted: loops.length,
+        loops,
+        verifiedLastLoop: lastLoop ? { loopNum: lastLoop.loop, totalGp: verifiedTotal, perBot: verifiedGp } : null,
+    }, null, 2));
+
+    console.log(`\nReward: ${reward}`);
+}
+
+main().catch(err => {
+    console.error('Verification error:', err);
+    try {
+        mkdirSync('/logs/verifier', { recursive: true });
+        writeFileSync('/logs/verifier/reward.txt', '0');
+        writeFileSync('/logs/verifier/reward.json', JSON.stringify({
+            reward: 0,
+            loopsCompleted: 0,
+            loops: [],
+            error: err.message,
+        }));
+    } catch {}
+    process.exit(1);
+});

--- a/shared/check_gp.ts
+++ b/shared/check_gp.ts
@@ -3,7 +3,7 @@
  * Reads per-loop GP results from /app/gp_results.json (written by the agent).
  * Also connects to bots from the last completed loop to verify inventory coins.
  *
- * Bot naming: l{loop}a{1-5} — e.g. l1a1, l1a2, ..., l5a5
+ * Bot naming: l{loop}a{1-2} — e.g. l1a1, l1a2, ..., l5a2
  *
  * Writes best loop GP to reward.txt for Harbor compatibility.
  * Writes full per-loop breakdown to reward.json for charting.
@@ -84,8 +84,8 @@ async function main() {
 
     if (lastLoop) {
         const loopNum = lastLoop.loop;
-        console.log(`\nVerifying loop ${loopNum} bots (l${loopNum}a1 - l${loopNum}a5)...`);
-        for (let i = 1; i <= 5; i++) {
+        console.log(`\nVerifying loop ${loopNum} bots (l${loopNum}a1 - l${loopNum}a2)...`);
+        for (let i = 1; i <= 2; i++) {
             const botName = `l${loopNum}a${i}`;
             const coins = await getCoinsForBot(botName);
             verifiedGp[botName] = coins;

--- a/shared/generate_gp_saves.ts
+++ b/shared/generate_gp_saves.ts
@@ -1,0 +1,56 @@
+/**
+ * Generate save files for the GP benchmark task.
+ * Creates 25 bot saves (5 bots x 5 loops) with level 50 in all skills,
+ * starting in Lumbridge with 0 coins.
+ *
+ * Naming: l{loop}a{bot} — e.g. l1a1, l1a2, ..., l5a5
+ * Each loop gets fresh usernames to avoid server caching issues.
+ *
+ * Usage: bun run benchmark/shared/generate_gp_saves.ts
+ */
+import { generateSave } from '../../sdk/test/utils/save-generator';
+
+const ALL_SKILLS: Record<string, number> = {
+  ATTACK: 50,
+  STRENGTH: 50,
+  DEFENCE: 50,
+  HITPOINTS: 50,
+  MAGIC: 50,
+  RANGED: 50,
+  PRAYER: 50,
+  WOODCUTTING: 50,
+  FISHING: 50,
+  MINING: 50,
+  COOKING: 50,
+  CRAFTING: 50,
+  SMITHING: 50,
+  FIREMAKING: 50,
+  FLETCHING: 50,
+  THIEVING: 50,
+  RUNECRAFT: 50,
+  HERBLORE: 50,
+  AGILITY: 50,
+};
+
+const LOOPS = 5;
+const BOTS_PER_LOOP = 5;
+
+async function main() {
+  let count = 0;
+  for (let loop = 1; loop <= LOOPS; loop++) {
+    for (let bot = 1; bot <= BOTS_PER_LOOP; bot++) {
+      const username = `l${loop}a${bot}`;
+      await generateSave(username, {
+        skills: ALL_SKILLS,
+        position: { x: 3222, z: 3218 }, // Lumbridge
+      });
+      count++;
+    }
+  }
+  console.log(`[generate_gp_saves] Created ${count} saves (${BOTS_PER_LOOP} bots x ${LOOPS} loops)`);
+}
+
+main().catch(err => {
+  console.error('[generate_gp_saves] Fatal:', err);
+  process.exit(1);
+});

--- a/shared/generate_gp_saves.ts
+++ b/shared/generate_gp_saves.ts
@@ -1,9 +1,9 @@
 /**
  * Generate save files for the GP benchmark task.
- * Creates 25 bot saves (5 bots x 5 loops) with level 50 in all skills
+ * Creates 15 bot saves (3 bots x 5 loops) with level 50 in all skills
  * (55 Magic for High Level Alchemy), starting in Lumbridge with tools and runes.
  *
- * Naming: l{loop}a{bot} — e.g. l1a1, l1a2, ..., l5a5
+ * Naming: l{loop}a{bot} — e.g. l1a1, l1a2, l1a3
  * Each loop gets fresh usernames to avoid server caching issues.
  *
  * Usage: bun run benchmark/shared/generate_gp_saves.ts
@@ -48,7 +48,7 @@ const STARTING_EQUIPMENT = [
 ];
 
 const LOOPS = 5;
-const BOTS_PER_LOOP = 5;
+const BOTS_PER_LOOP = 3;
 
 async function main() {
   let count = 0;

--- a/shared/generate_gp_saves.ts
+++ b/shared/generate_gp_saves.ts
@@ -1,9 +1,9 @@
 /**
  * Generate save files for the GP benchmark task.
- * Creates 15 bot saves (3 bots x 5 loops) with level 50 in all skills
+ * Creates 10 bot saves (2 bots x 5 loops) with level 50 in all skills
  * (55 Magic for High Level Alchemy), starting in Lumbridge with tools and runes.
  *
- * Naming: l{loop}a{bot} — e.g. l1a1, l1a2, l1a3
+ * Naming: l{loop}a{bot} — e.g. l1a1, l1a2
  * Each loop gets fresh usernames to avoid server caching issues.
  *
  * Usage: bun run benchmark/shared/generate_gp_saves.ts
@@ -48,7 +48,7 @@ const STARTING_EQUIPMENT = [
 ];
 
 const LOOPS = 5;
-const BOTS_PER_LOOP = 3;
+const BOTS_PER_LOOP = 2;
 
 async function main() {
   let count = 0;

--- a/shared/generate_gp_saves.ts
+++ b/shared/generate_gp_saves.ts
@@ -40,7 +40,6 @@ const STARTING_INVENTORY = [
   { id: 303, count: 1 },    // Small fishing net (fishing)
   { id: 2347, count: 1 },   // Hammer (smithing)
   { id: 561, count: 1000 }, // Nature runes (alchemy — stackable)
-  { id: 995, count: 200 },  // Coins (seed money — stackable)
 ];
 
 // Staff of fire equipped — unlimited fire runes for alchemy

--- a/shared/generate_gp_saves.ts
+++ b/shared/generate_gp_saves.ts
@@ -39,7 +39,7 @@ const STARTING_INVENTORY = [
   { id: 590, count: 1 },    // Tinderbox (firemaking/cooking)
   { id: 303, count: 1 },    // Small fishing net (fishing)
   { id: 2347, count: 1 },   // Hammer (smithing)
-  { id: 561, count: 300 },  // Nature runes (alchemy — stackable)
+  { id: 561, count: 1000 }, // Nature runes (alchemy — stackable)
   { id: 995, count: 200 },  // Coins (seed money — stackable)
 ];
 

--- a/shared/generate_gp_saves.ts
+++ b/shared/generate_gp_saves.ts
@@ -1,7 +1,7 @@
 /**
  * Generate save files for the GP benchmark task.
- * Creates 25 bot saves (5 bots x 5 loops) with level 50 in all skills,
- * starting in Lumbridge with 0 coins.
+ * Creates 25 bot saves (5 bots x 5 loops) with level 50 in all skills
+ * (55 Magic for High Level Alchemy), starting in Lumbridge with tools and runes.
  *
  * Naming: l{loop}a{bot} — e.g. l1a1, l1a2, ..., l5a5
  * Each loop gets fresh usernames to avoid server caching issues.
@@ -15,7 +15,7 @@ const ALL_SKILLS: Record<string, number> = {
   STRENGTH: 50,
   DEFENCE: 50,
   HITPOINTS: 50,
-  MAGIC: 50,
+  MAGIC: 55,     // 55 enables High Level Alchemy
   RANGED: 50,
   PRAYER: 50,
   WOODCUTTING: 50,
@@ -32,6 +32,22 @@ const ALL_SKILLS: Record<string, number> = {
   AGILITY: 50,
 };
 
+// Starting inventory — gives strategic optionality
+const STARTING_INVENTORY = [
+  { id: 1359, count: 1 },   // Rune axe (woodcutting — level 41 req)
+  { id: 946, count: 1 },    // Knife (fletching)
+  { id: 590, count: 1 },    // Tinderbox (firemaking/cooking)
+  { id: 303, count: 1 },    // Small fishing net (fishing)
+  { id: 2347, count: 1 },   // Hammer (smithing)
+  { id: 561, count: 300 },  // Nature runes (alchemy — stackable)
+  { id: 995, count: 200 },  // Coins (seed money — stackable)
+];
+
+// Staff of fire equipped — unlimited fire runes for alchemy
+const STARTING_EQUIPMENT = [
+  { id: 1387, count: 1, slot: 3 },  // Staff of fire in weapon slot
+];
+
 const LOOPS = 5;
 const BOTS_PER_LOOP = 5;
 
@@ -43,6 +59,8 @@ async function main() {
       await generateSave(username, {
         skills: ALL_SKILLS,
         position: { x: 3222, z: 3218 }, // Lumbridge
+        inventory: STARTING_INVENTORY,
+        equipment: STARTING_EQUIPMENT,
       });
       count++;
     }

--- a/shared/gp_fresh_start.ts
+++ b/shared/gp_fresh_start.ts
@@ -1,0 +1,107 @@
+/**
+ * freshStart() — reset a connected bot to the GP benchmark starting state.
+ *
+ * Uses in-game cheat commands (::setstat, ::give, ::unstuck) to set up the
+ * character live — no save file regeneration or reconnection needed.
+ *
+ * Usage inside execute_code:
+ *
+ *   const { freshStart } = await import('/app/benchmark/shared/gp_fresh_start.ts');
+ *   await freshStart();
+ *   // Bot is now at Lumbridge, level 50 all skills (55 Magic), with starting gear
+ *
+ * Call this at the top of every bot script before doing anything else.
+ */
+
+const SKILLS_TO_SET: Array<[string, number]> = [
+    ['attack',      50],
+    ['defence',     50],
+    ['strength',    50],
+    ['hitpoints',   50],
+    ['magic',       55],  // 55 = High Level Alchemy
+    ['ranged',      50],
+    ['prayer',      50],
+    ['woodcutting', 50],
+    ['fishing',     50],
+    ['mining',      50],
+    ['cooking',     50],
+    ['crafting',    50],
+    ['smithing',    50],
+    ['firemaking',  50],
+    ['fletching',   50],
+    ['thieving',    50],
+    ['runecrafting',50],
+    ['herblore',    50],
+    ['agility',     50],
+];
+
+const ITEMS_TO_GIVE: Array<[string, number]> = [
+    ['rune_axe',        1],
+    ['knife',           1],
+    ['tinderbox',       1],
+    ['small_fishing_net', 1],
+    ['hammer',          1],
+    ['nature_rune',     1000],
+];
+
+// Staff of fire: item ID 1387, equip to weapon slot (slot 3)
+const STAFF_OF_FIRE_ID = 1387;
+const STAFF_OF_FIRE_NAME = 'staff_of_fire';
+
+async function cheat(cmd: string): Promise<void> {
+    await sdk.sendSay(`::${cmd}`);
+    await sdk.waitForTicks(2);
+}
+
+export async function freshStart(): Promise<void> {
+    console.log('[freshStart] Resetting bot to GP benchmark starting state...');
+
+    // 1. Teleport to Lumbridge
+    await cheat('unstuck');
+    console.log('[freshStart] Teleported to Lumbridge');
+
+    // 2. Set all skills
+    for (const [skill, level] of SKILLS_TO_SET) {
+        await cheat(`setstat ${skill} ${level}`);
+    }
+    console.log('[freshStart] Skills set to level 50 (Magic 55)');
+
+    // 3. Clear inventory (drop everything)
+    const inv = sdk.getInventory();
+    for (let i = inv.length - 1; i >= 0; i--) {
+        await sdk.sendDropItem(i);
+        await sdk.waitForTicks(1);
+    }
+    console.log('[freshStart] Inventory cleared');
+
+    // 4. Give starting items
+    for (const [item, count] of ITEMS_TO_GIVE) {
+        await cheat(`give ${item} ${count}`);
+    }
+    console.log('[freshStart] Starting items given');
+
+    // 5. Give and equip staff of fire
+    await cheat(`give ${STAFF_OF_FIRE_NAME} 1`);
+    await sdk.waitForTicks(2);
+    const staffSlot = sdk.getInventory().findIndex(i => i.id === STAFF_OF_FIRE_ID);
+    if (staffSlot !== -1) {
+        await bot.equipItem(STAFF_OF_FIRE_ID);
+        console.log('[freshStart] Staff of fire equipped');
+    } else {
+        console.warn('[freshStart] WARNING: Staff of fire not found in inventory after give');
+    }
+
+    // 6. Verify state
+    await sdk.waitForTicks(3);
+    const state = sdk.getState();
+    const skills = sdk.getSkills();
+    const atk = skills.find(s => s.name.toUpperCase() === 'ATTACK');
+    const magic = skills.find(s => s.name.toUpperCase() === 'MAGIC');
+    const pos = `(${state?.player?.worldX}, ${state?.player?.worldZ})`;
+
+    console.log(`[freshStart] Done. Pos=${pos} Attack=${atk?.baseLevel} Magic=${magic?.baseLevel} Inv=${sdk.getInventory().length} items`);
+
+    if (!atk || atk.baseLevel < 50) {
+        console.warn('[freshStart] WARNING: Attack level is wrong:', atk?.baseLevel);
+    }
+}

--- a/shared/gp_fresh_start.ts
+++ b/shared/gp_fresh_start.ts
@@ -1,8 +1,12 @@
 /**
- * freshStart(sdk, bot) — reset a connected bot to the GP benchmark starting state.
+ * freshStart(sdk, bot) — ensure a connected bot is ready for the GP benchmark.
  *
- * Handles Tutorial Island / character creation automatically.
- * Uses cheat commands (::setstat, ::give, ::unstuck) for skill/item setup.
+ * The bot's save file already has the correct state (level 50 skills, 55 Magic,
+ * starting inventory, staff of fire equipped, Lumbridge position). This function
+ * just handles Tutorial Island / character creation if needed, then verifies.
+ *
+ * NOTE: Does NOT use cheat commands (::setstat, ::give) — they don't work on
+ * the Docker server because Client.ts doesn't convert :: to CLIENT_CHEAT packets.
  *
  * IMPORTANT: Pass sdk and bot explicitly — they are execute_code globals,
  * not available in module scope.
@@ -11,42 +15,8 @@
  *
  *   const { freshStart } = await import('/app/benchmark/shared/gp_fresh_start.ts');
  *   await freshStart(sdk, bot);
- *   // Bot is now at Lumbridge, level 50 all skills (55 Magic), with starting gear
+ *   // Bot is ready with save-loaded state
  */
-
-const SKILLS_TO_SET: Array<[string, number]> = [
-    ['attack',      50],
-    ['defence',     50],
-    ['strength',    50],
-    ['hitpoints',   50],
-    ['magic',       55],  // 55 = High Level Alchemy
-    ['ranged',      50],
-    ['prayer',      50],
-    ['woodcutting', 50],
-    ['fishing',     50],
-    ['mining',      50],
-    ['cooking',     50],
-    ['crafting',    50],
-    ['smithing',    50],
-    ['firemaking',  50],
-    ['fletching',   50],
-    ['thieving',    50],
-    ['runecrafting',50],
-    ['herblore',    50],
-    ['agility',     50],
-];
-
-const ITEMS_TO_GIVE: Array<[string, number]> = [
-    ['rune_axe',        1],
-    ['knife',           1],
-    ['tinderbox',       1],
-    ['small_fishing_net', 1],
-    ['hammer',          1],
-    ['nature_rune',     1000],
-];
-
-const STAFF_OF_FIRE_ID = 1387;
-const STAFF_OF_FIRE_NAME = 'staff_of_fire';
 
 // Tutorial Island bounds
 function isOnTutorialIsland(x: number, z: number): boolean {
@@ -72,12 +42,10 @@ export async function freshStart(sdk: any, bot: any): Promise<void> {
     state = sdk.getState();
     if (state?.interface?.id === 3559) {
         console.log('[freshStart] Character creation screen detected — accepting...');
-        // Try clicking "Accept" (option 1) in the interface
         const acceptOption = state.interface.options?.[0];
         if (acceptOption?.componentId) {
             await sdk.sendClickComponent(acceptOption.componentId);
         } else {
-            // Fallback: try sendCloseModal or sendClickDialog
             try { await sdk.sendCloseModal(); } catch {}
         }
         await sleep(3000);
@@ -108,56 +76,21 @@ export async function freshStart(sdk: any, bot: any): Promise<void> {
         await sleep(2000);
     }
 
-    // --- Phase 3: Teleport to Lumbridge ---
-    await sdk.sendSay('::unstuck');
-    await sleep(1500);
-    console.log('[freshStart] Teleported to Lumbridge');
-
-    // --- Phase 4: Set all skills ---
-    for (const [skill, level] of SKILLS_TO_SET) {
-        await sdk.sendSay(`::setstat ${skill} ${level}`);
-        await sleep(150);
-    }
-    console.log('[freshStart] Skills set to level 50 (Magic 55)');
-
-    // --- Phase 5: Clear inventory ---
-    await sleep(500);
-    const inv = sdk.getInventory();
-    for (let i = inv.length - 1; i >= 0; i--) {
-        await sdk.sendDropItem(i);
-        await sleep(100);
-    }
-    console.log('[freshStart] Inventory cleared');
-
-    // --- Phase 6: Give starting items ---
-    for (const [item, count] of ITEMS_TO_GIVE) {
-        await sdk.sendSay(`::give ${item} ${count}`);
-        await sleep(150);
-    }
-    console.log('[freshStart] Starting items given');
-
-    // --- Phase 7: Give and equip staff of fire ---
-    await sdk.sendSay(`::give ${STAFF_OF_FIRE_NAME} 1`);
-    await sleep(1000);
-    const staffSlot = sdk.getInventory().findIndex((i: any) => i.id === STAFF_OF_FIRE_ID);
-    if (staffSlot !== -1) {
-        await bot.equipItem(STAFF_OF_FIRE_ID);
-        await sleep(500);
-        console.log('[freshStart] Staff of fire equipped');
-    } else {
-        console.warn('[freshStart] WARNING: Staff of fire not found');
-    }
-
-    // --- Phase 8: Verify final state ---
+    // --- Phase 3: Verify state (from save file) ---
     await sleep(500);
     state = sdk.getState();
-    const skills = sdk.getSkills();
-    const atk = skills.find((s: any) => s.name.toUpperCase() === 'ATTACK');
-    const magic = skills.find((s: any) => s.name.toUpperCase() === 'MAGIC');
+    const skills = sdk.getSkills?.() ?? [];
+    const atk = skills.find((s: any) => s.name?.toUpperCase() === 'ATTACK');
+    const magic = skills.find((s: any) => s.name?.toUpperCase() === 'MAGIC');
+    const inv = sdk.getInventory();
     const pos = `(${state?.player?.worldX}, ${state?.player?.worldZ})`;
 
-    console.log(`[freshStart] Done. Pos=${pos} Attack=${atk?.baseLevel} Magic=${magic?.baseLevel} Inv=${sdk.getInventory().length} items`);
+    console.log(`[freshStart] Done. Pos=${pos} Attack=${atk?.baseLevel ?? '?'} Magic=${magic?.baseLevel ?? '?'} Inv=${inv.length} items`);
+    inv.forEach((i: any) => console.log(`[freshStart]   - ${i.name} x${i.count}`));
 
+    if (inv.length === 0) {
+        console.warn('[freshStart] WARNING: Empty inventory! Save file may not have loaded correctly.');
+    }
     if (!atk || atk.baseLevel < 50) {
         console.warn('[freshStart] WARNING: Attack level wrong:', atk?.baseLevel);
     }

--- a/shared/gp_fresh_start.ts
+++ b/shared/gp_fresh_start.ts
@@ -1,8 +1,8 @@
 /**
  * freshStart(sdk, bot) — reset a connected bot to the GP benchmark starting state.
  *
- * Uses in-game cheat commands (::setstat, ::give, ::unstuck) to set up the
- * character live — no save file regeneration or reconnection needed.
+ * Handles Tutorial Island / character creation automatically.
+ * Uses cheat commands (::setstat, ::give, ::unstuck) for skill/item setup.
  *
  * IMPORTANT: Pass sdk and bot explicitly — they are execute_code globals,
  * not available in module scope.
@@ -12,8 +12,6 @@
  *   const { freshStart } = await import('/app/benchmark/shared/gp_fresh_start.ts');
  *   await freshStart(sdk, bot);
  *   // Bot is now at Lumbridge, level 50 all skills (55 Magic), with starting gear
- *
- * Call this at the top of every bot script before doing anything else.
  */
 
 const SKILLS_TO_SET: Array<[string, number]> = [
@@ -47,56 +45,112 @@ const ITEMS_TO_GIVE: Array<[string, number]> = [
     ['nature_rune',     1000],
 ];
 
-// Staff of fire: item ID 1387
 const STAFF_OF_FIRE_ID = 1387;
 const STAFF_OF_FIRE_NAME = 'staff_of_fire';
 
-export async function freshStart(sdk: any, bot: any): Promise<void> {
-    console.log('[freshStart] Resetting bot to GP benchmark starting state...');
+// Tutorial Island bounds
+function isOnTutorialIsland(x: number, z: number): boolean {
+    return x >= 3050 && x <= 3156 && z >= 3056 && z <= 3136;
+}
 
-    async function cheat(cmd: string): Promise<void> {
-        await sdk.sendSay(`::${cmd}`);
-        await sdk.waitForTicks(2);
+export async function freshStart(sdk: any, bot: any): Promise<void> {
+    const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+    console.log('[freshStart] Starting...');
+
+    // --- Phase 0: Wait for initial state ---
+    let state = sdk.getState();
+    for (let i = 0; i < 30 && !state?.player; i++) {
+        await sleep(500);
+        state = sdk.getState();
+    }
+    if (!state?.player) {
+        console.warn('[freshStart] WARNING: No player state after 15s, proceeding anyway');
     }
 
-    // 1. Teleport to Lumbridge
-    await cheat('unstuck');
+    // --- Phase 1: Handle character creation screen (interface 3559) ---
+    state = sdk.getState();
+    if (state?.interface?.id === 3559) {
+        console.log('[freshStart] Character creation screen detected — accepting...');
+        // Try clicking "Accept" (option 1) in the interface
+        const acceptOption = state.interface.options?.[0];
+        if (acceptOption?.componentId) {
+            await sdk.sendClickComponent(acceptOption.componentId);
+        } else {
+            // Fallback: try sendCloseModal or sendClickDialog
+            try { await sdk.sendCloseModal(); } catch {}
+        }
+        await sleep(3000);
+    }
+
+    // --- Phase 2: Skip Tutorial Island if needed ---
+    state = sdk.getState();
+    const px = state?.player?.worldX ?? 0;
+    const pz = state?.player?.worldZ ?? 0;
+
+    if (isOnTutorialIsland(px, pz)) {
+        console.log('[freshStart] On Tutorial Island — skipping tutorial...');
+        for (let attempt = 0; attempt < 30; attempt++) {
+            try {
+                await bot.skipTutorial();
+            } catch (e: any) {
+                // skipTutorial errors are expected mid-transition — keep trying
+            }
+            await sleep(1000);
+            state = sdk.getState();
+            const x = state?.player?.worldX ?? 0;
+            const z = state?.player?.worldZ ?? 0;
+            if (!isOnTutorialIsland(x, z)) {
+                console.log(`[freshStart] Left Tutorial Island → (${x}, ${z})`);
+                break;
+            }
+        }
+        await sleep(2000);
+    }
+
+    // --- Phase 3: Teleport to Lumbridge ---
+    await sdk.sendSay('::unstuck');
+    await sleep(1500);
     console.log('[freshStart] Teleported to Lumbridge');
 
-    // 2. Set all skills
+    // --- Phase 4: Set all skills ---
     for (const [skill, level] of SKILLS_TO_SET) {
-        await cheat(`setstat ${skill} ${level}`);
+        await sdk.sendSay(`::setstat ${skill} ${level}`);
+        await sleep(150);
     }
     console.log('[freshStart] Skills set to level 50 (Magic 55)');
 
-    // 3. Clear inventory (drop everything)
+    // --- Phase 5: Clear inventory ---
+    await sleep(500);
     const inv = sdk.getInventory();
     for (let i = inv.length - 1; i >= 0; i--) {
         await sdk.sendDropItem(i);
-        await sdk.waitForTicks(1);
+        await sleep(100);
     }
     console.log('[freshStart] Inventory cleared');
 
-    // 4. Give starting items
+    // --- Phase 6: Give starting items ---
     for (const [item, count] of ITEMS_TO_GIVE) {
-        await cheat(`give ${item} ${count}`);
+        await sdk.sendSay(`::give ${item} ${count}`);
+        await sleep(150);
     }
     console.log('[freshStart] Starting items given');
 
-    // 5. Give and equip staff of fire
-    await cheat(`give ${STAFF_OF_FIRE_NAME} 1`);
-    await sdk.waitForTicks(2);
+    // --- Phase 7: Give and equip staff of fire ---
+    await sdk.sendSay(`::give ${STAFF_OF_FIRE_NAME} 1`);
+    await sleep(1000);
     const staffSlot = sdk.getInventory().findIndex((i: any) => i.id === STAFF_OF_FIRE_ID);
     if (staffSlot !== -1) {
         await bot.equipItem(STAFF_OF_FIRE_ID);
+        await sleep(500);
         console.log('[freshStart] Staff of fire equipped');
     } else {
-        console.warn('[freshStart] WARNING: Staff of fire not found in inventory after give');
+        console.warn('[freshStart] WARNING: Staff of fire not found');
     }
 
-    // 6. Verify state
-    await sdk.waitForTicks(3);
-    const state = sdk.getState();
+    // --- Phase 8: Verify final state ---
+    await sleep(500);
+    state = sdk.getState();
     const skills = sdk.getSkills();
     const atk = skills.find((s: any) => s.name.toUpperCase() === 'ATTACK');
     const magic = skills.find((s: any) => s.name.toUpperCase() === 'MAGIC');
@@ -105,6 +159,6 @@ export async function freshStart(sdk: any, bot: any): Promise<void> {
     console.log(`[freshStart] Done. Pos=${pos} Attack=${atk?.baseLevel} Magic=${magic?.baseLevel} Inv=${sdk.getInventory().length} items`);
 
     if (!atk || atk.baseLevel < 50) {
-        console.warn('[freshStart] WARNING: Attack level is wrong:', atk?.baseLevel);
+        console.warn('[freshStart] WARNING: Attack level wrong:', atk?.baseLevel);
     }
 }

--- a/shared/gp_fresh_start.ts
+++ b/shared/gp_fresh_start.ts
@@ -1,13 +1,16 @@
 /**
- * freshStart() — reset a connected bot to the GP benchmark starting state.
+ * freshStart(sdk, bot) — reset a connected bot to the GP benchmark starting state.
  *
  * Uses in-game cheat commands (::setstat, ::give, ::unstuck) to set up the
  * character live — no save file regeneration or reconnection needed.
  *
+ * IMPORTANT: Pass sdk and bot explicitly — they are execute_code globals,
+ * not available in module scope.
+ *
  * Usage inside execute_code:
  *
  *   const { freshStart } = await import('/app/benchmark/shared/gp_fresh_start.ts');
- *   await freshStart();
+ *   await freshStart(sdk, bot);
  *   // Bot is now at Lumbridge, level 50 all skills (55 Magic), with starting gear
  *
  * Call this at the top of every bot script before doing anything else.
@@ -44,17 +47,17 @@ const ITEMS_TO_GIVE: Array<[string, number]> = [
     ['nature_rune',     1000],
 ];
 
-// Staff of fire: item ID 1387, equip to weapon slot (slot 3)
+// Staff of fire: item ID 1387
 const STAFF_OF_FIRE_ID = 1387;
 const STAFF_OF_FIRE_NAME = 'staff_of_fire';
 
-async function cheat(cmd: string): Promise<void> {
-    await sdk.sendSay(`::${cmd}`);
-    await sdk.waitForTicks(2);
-}
-
-export async function freshStart(): Promise<void> {
+export async function freshStart(sdk: any, bot: any): Promise<void> {
     console.log('[freshStart] Resetting bot to GP benchmark starting state...');
+
+    async function cheat(cmd: string): Promise<void> {
+        await sdk.sendSay(`::${cmd}`);
+        await sdk.waitForTicks(2);
+    }
 
     // 1. Teleport to Lumbridge
     await cheat('unstuck');
@@ -83,7 +86,7 @@ export async function freshStart(): Promise<void> {
     // 5. Give and equip staff of fire
     await cheat(`give ${STAFF_OF_FIRE_NAME} 1`);
     await sdk.waitForTicks(2);
-    const staffSlot = sdk.getInventory().findIndex(i => i.id === STAFF_OF_FIRE_ID);
+    const staffSlot = sdk.getInventory().findIndex((i: any) => i.id === STAFF_OF_FIRE_ID);
     if (staffSlot !== -1) {
         await bot.equipItem(STAFF_OF_FIRE_ID);
         console.log('[freshStart] Staff of fire equipped');
@@ -95,8 +98,8 @@ export async function freshStart(): Promise<void> {
     await sdk.waitForTicks(3);
     const state = sdk.getState();
     const skills = sdk.getSkills();
-    const atk = skills.find(s => s.name.toUpperCase() === 'ATTACK');
-    const magic = skills.find(s => s.name.toUpperCase() === 'MAGIC');
+    const atk = skills.find((s: any) => s.name.toUpperCase() === 'ATTACK');
+    const magic = skills.find((s: any) => s.name.toUpperCase() === 'MAGIC');
     const pos = `(${state?.player?.worldX}, ${state?.player?.worldZ})`;
 
     console.log(`[freshStart] Done. Pos=${pos} Attack=${atk?.baseLevel} Magic=${magic?.baseLevel} Inv=${sdk.getInventory().length} items`);

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -7,10 +7,9 @@ This is a local RuneScape private server running on localhost for AI agent bench
 1. **Read `/app/gp_results.json`** to determine your loop number. Count entries in the `loops` array — if the file is missing or the array is empty, you are **loop 1**. Otherwise you are loop N+1.
 2. **Read `/app/learnings.md`** for what previous agents learned (empty on loop 1).
 3. **Read the SDK docs** at `/app/sdk/API.md` and files in `/app/learnings/` to understand available game APIs. On loop 1 especially, spend time here.
-4. **Write your scripts** — one per bot. You can run the same script on all 5 bots or different scripts on different bots.
-5. **Run all 5 scripts in parallel** using `execute_code(bot_name, code)` on each of your loop's bots.
-6. **Record results** to `/app/gp_results.json` (read existing file first, append your entry).
-7. **Update `/app/learnings.md`** with what you learned for the next agent.
+4. **Write one money-making script** and run it on all 5 bots in parallel using `execute_code(bot_name, code)`.
+5. **Record results** to `/app/gp_results.json` (read existing file first, append your entry).
+6. **Update `/app/learnings.md`** with what you learned for the next agent.
 
 ## Your Bots
 
@@ -21,45 +20,32 @@ Each loop uses a unique set of 5 bots that start fresh (level 50 all skills, 0 c
 - Loop 4: `l4a1`, `l4a2`, `l4a3`, `l4a4`, `l4a5`
 - Loop 5: `l5a1`, `l5a2`, `l5a3`, `l5a4`, `l5a5`
 
-Use `execute_code(bot_name, code)` with the bot names for YOUR loop.
+Write **one script** and run it on all 5 of your loop's bots using `execute_code(bot_name, code)`.
 
 ## Rules
 
 - **No pickpocketing** — any other money-making method is fair game
 - **10,000 tick limit** — each bot's script must finish within 10,000 game ticks
 - **GP is measured from inventory** — coins must be in inventory, not banked, at the end
-- **5 script runs per loop** — one per bot, all run in parallel. You can use the same script on all 5 bots or different scripts on different bots.
+- **Same script on all 5 bots** — write one script, run it 5 times in parallel
 
 ## GP Tracking Within Scripts
 
-Your scripts MUST track GP throughout execution. Every ~30 seconds (500 ticks), check coins and log the count. At the end of the script, return the final coin count. Example pattern:
+Your scripts MUST track GP throughout execution. Every ~500 ticks, check coins and log the count. At the end, return the final coin count:
 
 ```typescript
 const COINS_ID = 995;
-let lastGp = 0;
-
-// ... your money-making logic with periodic GP checks ...
 const inv = sdk.getInventory();
 const coins = inv?.filter(i => i.id === COINS_ID).reduce((sum, i) => sum + i.count, 0) ?? 0;
-lastGp = coins;
-console.log(\`[GP check] \${coins} coins at tick \${currentTick}\`);
-
-// At the very end:
-return { gp: lastGp };
+console.log(\`[GP] \${coins} coins\`);
+return { gp: coins };
 ```
 
-The last recorded GP value is the one that counts for that bot. If the script errors partway through, whatever GP was last measured is still counted.
-
-## Handling Errors
-
-If a script errors, don't panic. The GP earned up to that point still counts (from the last periodic check). In your learnings, explain:
-- What error occurred and why
-- At what point in the script it happened
-- What you'd change to fix it
+If the script errors partway through, whatever GP was last measured still counts.
 
 ## Recording Results
 
-After all 5 scripts complete, check final coins on each bot and write to `/app/gp_results.json`:
+After all 5 bots finish, check final coins on each and write to `/app/gp_results.json`:
 ```json
 {
   "loops": [
@@ -77,20 +63,18 @@ After all 5 scripts complete, check final coins on each bot and write to `/app/g
 
 ## Writing Learnings (CRITICAL)
 
-`/app/learnings.md` and `/app/gp_results.json` are the only things that carry forward to the next agent. Write learnings well:
-- **What method you tried** and why
-- **Exact GP earned** and GP/tick rate
-- **What worked** — specific code patterns, coordinates, NPC interactions that succeeded
-- **What failed** — errors, pathing issues, timing problems, things that didn't earn as much as expected
-- **Specific recommendations for the next agent** — "try X instead of Y", "the shop at Z overstocks after N sales", "high-alch is better than selling because..."
-- **Working code snippets** — the next agent starts completely fresh, so include copy-pasteable code that works
+`/app/learnings.md` and `/app/gp_results.json` are the only things that carry forward. Write learnings well:
+- **What method you tried** and exact GP earned / GP per tick
+- **What worked** — specific code patterns, coordinates, NPC interactions
+- **What failed** — errors, pathing issues, things that earned less than expected
+- **Recommendations for the next agent** — "try X instead of Y", "shop at Z overstocks after N sales"
+- **Working code snippets** — the next agent starts fresh, so include copy-pasteable code
 
 ## Strategy Suggestions
 
-- Consider: selling to shops (beware overstocking!), high-alchemy, crafting + selling, resource gathering + selling, monster loot
-- 5 bots doing the same proven method in parallel vs. coordinated supply chains (gatherers then crafters then sellers) — which earns more GP/tick?
+- Selling to shops (beware overstocking!), high-alchemy, crafting + selling, resource gathering + selling, monster loot
 - Early loops should explore different methods. Later loops should exploit the best method found so far.
-- Think about bottlenecks: shop stock limits, resource competition between bots, travel time
+- Think about bottlenecks: shop stock limits, resource competition between 5 bots, travel time
 
 ## Reference
 

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -1,0 +1,99 @@
+You are one agent in a 5-loop iterative GP-earning benchmark. You have been spawned fresh for **one loop**. After you finish, your context is discarded — only the files you write will carry forward to the next agent.
+
+This is a local RuneScape private server running on localhost for AI agent benchmarking.
+
+## Your Process
+
+1. **Read `/app/gp_results.json`** to determine your loop number. Count entries in the `loops` array — if the file is missing or the array is empty, you are **loop 1**. Otherwise you are loop N+1.
+2. **Read `/app/learnings.md`** for what previous agents learned (empty on loop 1).
+3. **Read the SDK docs** at `/app/sdk/API.md` and files in `/app/learnings/` to understand available game APIs. On loop 1 especially, spend time here.
+4. **Write your scripts** — one per bot. You can run the same script on all 5 bots or different scripts on different bots.
+5. **Run all 5 scripts in parallel** using `execute_code(bot_name, code)` on each of your loop's bots.
+6. **Record results** to `/app/gp_results.json` (read existing file first, append your entry).
+7. **Update `/app/learnings.md`** with what you learned for the next agent.
+
+## Your Bots
+
+Each loop uses a unique set of 5 bots that start fresh (level 50 all skills, 0 coins, Lumbridge). Bot names follow the pattern `l{loop}a{1-5}`:
+- Loop 1: `l1a1`, `l1a2`, `l1a3`, `l1a4`, `l1a5`
+- Loop 2: `l2a1`, `l2a2`, `l2a3`, `l2a4`, `l2a5`
+- Loop 3: `l3a1`, `l3a2`, `l3a3`, `l3a4`, `l3a5`
+- Loop 4: `l4a1`, `l4a2`, `l4a3`, `l4a4`, `l4a5`
+- Loop 5: `l5a1`, `l5a2`, `l5a3`, `l5a4`, `l5a5`
+
+Use `execute_code(bot_name, code)` with the bot names for YOUR loop.
+
+## Rules
+
+- **No pickpocketing** — any other money-making method is fair game
+- **10,000 tick limit** — each bot's script must finish within 10,000 game ticks
+- **GP is measured from inventory** — coins must be in inventory, not banked, at the end
+- **5 script runs per loop** — one per bot, all run in parallel. You can use the same script on all 5 bots or different scripts on different bots.
+
+## GP Tracking Within Scripts
+
+Your scripts MUST track GP throughout execution. Every ~30 seconds (500 ticks), check coins and log the count. At the end of the script, return the final coin count. Example pattern:
+
+```typescript
+const COINS_ID = 995;
+let lastGp = 0;
+
+// ... your money-making logic with periodic GP checks ...
+const inv = sdk.getInventory();
+const coins = inv?.filter(i => i.id === COINS_ID).reduce((sum, i) => sum + i.count, 0) ?? 0;
+lastGp = coins;
+console.log(\`[GP check] \${coins} coins at tick \${currentTick}\`);
+
+// At the very end:
+return { gp: lastGp };
+```
+
+The last recorded GP value is the one that counts for that bot. If the script errors partway through, whatever GP was last measured is still counted.
+
+## Handling Errors
+
+If a script errors, don't panic. The GP earned up to that point still counts (from the last periodic check). In your learnings, explain:
+- What error occurred and why
+- At what point in the script it happened
+- What you'd change to fix it
+
+## Recording Results
+
+After all 5 scripts complete, check final coins on each bot and write to `/app/gp_results.json`:
+```json
+{
+  "loops": [
+    {
+      "loop": 1,
+      "totalGp": 12500,
+      "perBot": { "l1a1": 2500, "l1a2": 2500, "l1a3": 2500, "l1a4": 2500, "l1a5": 2500 },
+      "method": "sold oak logs to general store",
+      "gpPerTick": 1.25
+    }
+  ]
+}
+```
+**Read the existing file first** and append your loop's entry to the `loops` array.
+
+## Writing Learnings (CRITICAL)
+
+`/app/learnings.md` and `/app/gp_results.json` are the only things that carry forward to the next agent. Write learnings well:
+- **What method you tried** and why
+- **Exact GP earned** and GP/tick rate
+- **What worked** — specific code patterns, coordinates, NPC interactions that succeeded
+- **What failed** — errors, pathing issues, timing problems, things that didn't earn as much as expected
+- **Specific recommendations for the next agent** — "try X instead of Y", "the shop at Z overstocks after N sales", "high-alch is better than selling because..."
+- **Working code snippets** — the next agent starts completely fresh, so include copy-pasteable code that works
+
+## Strategy Suggestions
+
+- Consider: selling to shops (beware overstocking!), high-alchemy, crafting + selling, resource gathering + selling, monster loot
+- 5 bots doing the same proven method in parallel vs. coordinated supply chains (gatherers then crafters then sellers) — which earns more GP/tick?
+- Early loops should explore different methods. Later loops should exploit the best method found so far.
+- Think about bottlenecks: shop stock limits, resource competition between bots, travel time
+
+## Reference
+
+- SDK API docs: `/app/sdk/API.md`
+- Game tips: `/app/learnings/` (banking, combat, shops, etc.)
+- Codebase: `/app`

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -8,20 +8,20 @@ This is a local RuneScape private server running on localhost for AI agent bench
 2. **Read `/app/learnings.md`** for what previous agents learned (empty on loop 1).
 3. **Read the SDK docs** at `/app/sdk/API.md` and files in `/app/learnings/` to understand available game APIs. On loop 1 especially, spend time here.
 4. **Write one money-making script** — a single block of TypeScript code that earns as much GP as possible within 10,000 game ticks (~9 minutes at 50ms/tick).
-5. **Run it on all 5 bots at once** — send all 5 `execute_code(bot_name, code, timeout=9)` calls in a **SINGLE assistant message** so they execute in parallel. Do NOT run them one at a time.
+5. **Run it on 3 bots sequentially** — call `execute_code(bot_name, code, timeout=9)` for each of your 3 bots one at a time.
 6. **Record results** to `/app/gp_results.json` (read existing file first, append your entry).
 7. **Update `/app/learnings.md`** with what you learned for the next agent.
 
-**TIME BUDGET: You have at most 30 minutes. Aim for 15.** Read docs (3 min) → Write script (5 min) → Run on all 5 bots in parallel (9 min) → Record results and learnings (3 min).
+**TIME BUDGET: You have at most 60 minutes.** Read docs (5 min) → Write script (10 min) → Run on 3 bots sequentially (27 min) → Record results and learnings (5 min).
 
 ## Your Bots
 
-Each loop uses a unique set of 5 bots. Bot names follow the pattern `l{loop}a{1-5}`:
-- Loop 1: `l1a1`, `l1a2`, `l1a3`, `l1a4`, `l1a5`
-- Loop 2: `l2a1`, `l2a2`, `l2a3`, `l2a4`, `l2a5`
-- Loop 3: `l3a1`, `l3a2`, `l3a3`, `l3a4`, `l3a5`
-- Loop 4: `l4a1`, `l4a2`, `l4a3`, `l4a4`, `l4a5`
-- Loop 5: `l5a1`, `l5a2`, `l5a3`, `l5a4`, `l5a5`
+Each loop uses a unique set of 3 bots. Bot names follow the pattern `l{loop}a{1-3}`:
+- Loop 1: `l1a1`, `l1a2`, `l1a3`
+- Loop 2: `l2a1`, `l2a2`, `l2a3`
+- Loop 3: `l3a1`, `l3a2`, `l3a3`
+- Loop 4: `l4a1`, `l4a2`, `l4a3`
+- Loop 5: `l5a1`, `l5a2`, `l5a3`
 
 **Bots are pre-connected and ready to use.** Just call `execute_code(bot_name, code)` directly — no browser launch needed.
 
@@ -40,8 +40,8 @@ You do NOT need to bootstrap (earn money for tools, etc.) — bots start fully e
 - **No pickpocketing** — any other money-making method is fair game
 - **10,000 tick limit** — the game runs at 50ms/tick, so 10,000 ticks ≈ 8.3 minutes. Set execute_code timeout to **9** (minutes).
 - **GP is measured from inventory** — coins must be in inventory at the end
-- **Same script on all 5 bots** — write ONE script, run it 5 times in parallel
-- **All 5 execute_code calls in ONE tool response** — this ensures parallel execution
+- **Same script on all 3 bots** — write ONE script, run it 3 times sequentially
+- **`sdk` is NOT available outside execute_code** — do not try to run scripts with `bun run`, they will fail. The only way to execute bot code is via `execute_code(bot_name, code)`.
 
 ## Notes
 
@@ -93,7 +93,7 @@ After all 5 bots finish, write to `/app/gp_results.json`:
     {
       "loop": 1,
       "totalGp": 12500,
-      "perBot": { "l1a1": 2500, "l1a2": 2500, "l1a3": 2500, "l1a4": 2500, "l1a5": 2500 },
+      "perBot": { "l1a1": 2500, "l1a2": 2500, "l1a3": 2500 },
       "method": "description of strategy used",
       "gpPerTick": 1.25
     }

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -47,7 +47,24 @@ You do NOT need to bootstrap (earn money for tools, etc.) — bots start fully e
 
 ## Notes
 
-**High Alchemy**: You can cast High Level Alchemy on items to convert them to coins. Switch to magic tab `sdk.sendSetTab(6)`, then use the item on the spell. Each cast costs 1 nature rune (fire runes are free from equipped staff). You start with 1,000 nature runes.
+**High Level Alchemy (HLA)** — the best GP method. Converts items into coins. Each cast costs 1 nature rune (fire runes free from staff). You start with 1,000 nature runes.
+
+**How to cast HLA:**
+```typescript
+// Switch to magic tab first
+await sdk.sendSetTab(6);
+await new Promise(r => setTimeout(r, 300));
+
+// Cast High Level Alchemy on an inventory item
+// Component ID 1178 = High Level Alchemy spell
+// Component ID 1162 = Low Level Alchemy spell
+await sdk.sendSpellOnItem(itemSlot, 1178);
+await new Promise(r => setTimeout(r, 150)); // wait ~3 ticks between casts
+```
+
+**What to alch**: Chop trees → get logs → alch logs. Or buy items from shops and alch them. Yew longbows alch for 768gp, maple longbows for 576gp, regular logs alch for very little. Higher-value items = more GP per nature rune.
+
+**Fletching for profit**: Use knife on logs to fletch into bows (more alch value). `await bot.fletchLogs()` fletches logs in inventory.
 
 **Shop overstocking warning**: All 5 loops share the same game server. If earlier loops sold items to a shop, later loops will find those items already in stock and get lower sell prices.
 

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -112,14 +112,6 @@ After all 5 bots finish, write to `/app/gp_results.json`:
 - **The FULL working script** — include the complete script that worked best so the next agent can copy-paste and improve it
 - **Shop stock levels** — if you sold to shops, note how many items are now in stock
 
-## Key Coordinates
-
-- Lumbridge General Store: (3212, 3247) — shopkeeper + shop assistant
-- Bob's Axes (Lumbridge): (3230, 3203)
-- Oak trees near Lumbridge store: (3203, 3246) — 6 tiles from general store
-- Varrock General Store: (3219, 3415) — may have fresh stock if Lumbridge is overstocked
-- Draynor fishing: (3087, 3230) — **DANGEROUS: dark wizards nearby, avoid at low combat**
-
 ## Reference
 
 - SDK API docs: `/app/sdk/API.md`

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -9,6 +9,8 @@ This is a local RuneScape private server running on localhost for AI agent bench
 3. **Read the SDK docs** at `/app/sdk/API.md` and files in `/app/learnings/` to understand available game APIs. On loop 1 especially, spend time here.
 4. **Write one money-making script** — a single block of TypeScript code that earns as much GP as possible within 10,000 game ticks (~9 minutes at 50ms/tick).
 5. **Run it on 2 bots sequentially** — call `execute_code(bot_name, code, timeout=9)` for each of your 2 bots one at a time.
+
+**Always call `freshStart()` at the top of your script** to guarantee the bot has the correct starting state (level 50 skills, starting items, Lumbridge position). This takes ~10 seconds.
 6. **Record results** to `/app/gp_results.json` (read existing file first, append your entry).
 7. **Update `/app/learnings.md`** with what you learned for the next agent.
 
@@ -51,7 +53,17 @@ You do NOT need to bootstrap (earn money for tools, etc.) — bots start fully e
 
 ## Script Template
 
-Use **game ticks** for timing, not wall-clock time:
+Always start with `freshStart()` to reset the bot to the correct state:
+
+```typescript
+const { freshStart } = await import('/app/benchmark/shared/gp_fresh_start.ts');
+await freshStart();
+// Bot is now at Lumbridge, level 50 all skills (55 Magic), holding:
+//   rune_axe, knife, tinderbox, fishing net, hammer, 1000 nature runes
+//   staff of fire equipped (unlimited fire runes for alchemy)
+```
+
+Then use **game ticks** for timing:
 
 ```typescript
 const COINS_ID = 995;

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -8,20 +8,20 @@ This is a local RuneScape private server running on localhost for AI agent bench
 2. **Read `/app/learnings.md`** for what previous agents learned (empty on loop 1).
 3. **Read the SDK docs** at `/app/sdk/API.md` and files in `/app/learnings/` to understand available game APIs. On loop 1 especially, spend time here.
 4. **Write one money-making script** — a single block of TypeScript code that earns as much GP as possible within 10,000 game ticks (~9 minutes at 50ms/tick).
-5. **Run it on 3 bots sequentially** — call `execute_code(bot_name, code, timeout=9)` for each of your 3 bots one at a time.
+5. **Run it on 2 bots sequentially** — call `execute_code(bot_name, code, timeout=9)` for each of your 2 bots one at a time.
 6. **Record results** to `/app/gp_results.json` (read existing file first, append your entry).
 7. **Update `/app/learnings.md`** with what you learned for the next agent.
 
-**TIME BUDGET: You have at most 60 minutes.** Read docs (5 min) → Write script (10 min) → Run on 3 bots sequentially (27 min) → Record results and learnings (5 min).
+**TIME BUDGET: You have at most 60 minutes.** Read docs (5 min) → Write script (10 min) → Run on 2 bots sequentially (18 min) → Record results and learnings (5 min).
 
 ## Your Bots
 
-Each loop uses a unique set of 3 bots. Bot names follow the pattern `l{loop}a{1-3}`:
-- Loop 1: `l1a1`, `l1a2`, `l1a3`
-- Loop 2: `l2a1`, `l2a2`, `l2a3`
-- Loop 3: `l3a1`, `l3a2`, `l3a3`
-- Loop 4: `l4a1`, `l4a2`, `l4a3`
-- Loop 5: `l5a1`, `l5a2`, `l5a3`
+Each loop uses a unique set of 2 bots. Bot names follow the pattern `l{loop}a{1-2}`:
+- Loop 1: `l1a1`, `l1a2`
+- Loop 2: `l2a1`, `l2a2`
+- Loop 3: `l3a1`, `l3a2`
+- Loop 4: `l4a1`, `l4a2`
+- Loop 5: `l5a1`, `l5a2`
 
 **Bots are pre-connected and ready to use.** Just call `execute_code(bot_name, code)` directly — no browser launch needed.
 
@@ -40,7 +40,7 @@ You do NOT need to bootstrap (earn money for tools, etc.) — bots start fully e
 - **No pickpocketing** — any other money-making method is fair game
 - **10,000 tick limit** — the game runs at 50ms/tick, so 10,000 ticks ≈ 8.3 minutes. Set execute_code timeout to **9** (minutes).
 - **GP is measured from inventory** — coins must be in inventory at the end
-- **Same script on all 3 bots** — write ONE script, run it 3 times sequentially
+- **Same script on all 2 bots** — write ONE script, run it 2 times sequentially
 - **`sdk` is NOT available outside execute_code** — do not try to run scripts with `bun run`, they will fail. The only way to execute bot code is via `execute_code(bot_name, code)`.
 
 ## Notes
@@ -86,14 +86,14 @@ return { gp: finalGp };
 
 ## Recording Results
 
-After all 5 bots finish, write to `/app/gp_results.json`:
+After all 2 bots finish, write to `/app/gp_results.json`:
 ```json
 {
   "loops": [
     {
       "loop": 1,
-      "totalGp": 12500,
-      "perBot": { "l1a1": 2500, "l1a2": 2500, "l1a3": 2500 },
+      "totalGp": 5000,
+      "perBot": { "l1a1": 2500, "l1a2": 2500 },
       "method": "description of strategy used",
       "gpPerTick": 1.25
     }

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -7,45 +7,94 @@ This is a local RuneScape private server running on localhost for AI agent bench
 1. **Read `/app/gp_results.json`** to determine your loop number. Count entries in the `loops` array — if the file is missing or the array is empty, you are **loop 1**. Otherwise you are loop N+1.
 2. **Read `/app/learnings.md`** for what previous agents learned (empty on loop 1).
 3. **Read the SDK docs** at `/app/sdk/API.md` and files in `/app/learnings/` to understand available game APIs. On loop 1 especially, spend time here.
-4. **Write one money-making script** and run it on all 5 bots in parallel using `execute_code(bot_name, code)`.
-5. **Record results** to `/app/gp_results.json` (read existing file first, append your entry).
-6. **Update `/app/learnings.md`** with what you learned for the next agent.
+4. **Write one money-making script** — a single block of TypeScript code that earns as much GP as possible within 10,000 game ticks (~9 minutes at 50ms/tick).
+5. **Run it on all 5 bots at once** — send all 5 `execute_code(bot_name, code, timeout=9)` calls in a **SINGLE assistant message** so they execute in parallel. Do NOT run them one at a time.
+6. **Record results** to `/app/gp_results.json` (read existing file first, append your entry).
+7. **Update `/app/learnings.md`** with what you learned for the next agent.
+
+**TIME BUDGET: You have at most 25 minutes. Aim for 15.** Read docs (3 min) → Write script (5 min) → Run on all 5 bots in parallel (9 min) → Record results and learnings (3 min).
 
 ## Your Bots
 
-Each loop uses a unique set of 5 bots that start fresh (level 50 all skills, 0 coins, Lumbridge). Bot names follow the pattern `l{loop}a{1-5}`:
+Each loop uses a unique set of 5 bots. Bot names follow the pattern `l{loop}a{1-5}`:
 - Loop 1: `l1a1`, `l1a2`, `l1a3`, `l1a4`, `l1a5`
 - Loop 2: `l2a1`, `l2a2`, `l2a3`, `l2a4`, `l2a5`
 - Loop 3: `l3a1`, `l3a2`, `l3a3`, `l3a4`, `l3a5`
 - Loop 4: `l4a1`, `l4a2`, `l4a3`, `l4a4`, `l4a5`
 - Loop 5: `l5a1`, `l5a2`, `l5a3`, `l5a4`, `l5a5`
 
-Write **one script** and run it on all 5 of your loop's bots using `execute_code(bot_name, code)`.
+**Bots are pre-connected and ready to use.** Just call `execute_code(bot_name, code)` directly — no browser launch needed.
+
+## Starting Conditions
+
+Each bot starts with:
+- **Level 50** in all skills (**55 Magic** — enough for High Level Alchemy)
+- **Position**: Lumbridge (3222, 3218)
+- **Inventory**: Rune axe, Knife, Tinderbox, Small fishing net, Hammer, 300 Nature runes, 200 Coins
+- **Equipped**: Staff of fire (provides unlimited fire runes)
+
+You do NOT need to bootstrap (earn money for tools, etc.) — bots start fully equipped.
 
 ## Rules
 
 - **No pickpocketing** — any other money-making method is fair game
-- **10,000 tick limit** — each bot's script must finish within 10,000 game ticks
-- **GP is measured from inventory** — coins must be in inventory, not banked, at the end
-- **Same script on all 5 bots** — write one script, run it 5 times in parallel
+- **10,000 tick limit** — the game runs at 50ms/tick, so 10,000 ticks ≈ 8.3 minutes. Set execute_code timeout to **9** (minutes).
+- **GP is measured from inventory** — coins must be in inventory at the end
+- **Same script on all 5 bots** — write ONE script, run it 5 times in parallel
+- **All 5 execute_code calls in ONE tool response** — this ensures parallel execution
 
-## GP Tracking Within Scripts
+## Strategy Options
 
-Your scripts MUST track GP throughout execution. Every ~500 ticks, check coins and log the count. At the end, return the final coin count:
+Your starting items enable several approaches:
+
+1. **Woodcut → Fletch → High Alchemy** — Chop oak logs (rune axe), fletch into longbows (knife), cast High Alchemy for ~48 GP per bow. Uses nature runes + staff of fire. **No shop needed — avoids overstocking.**
+2. **Woodcut → Fletch → Sell to shop** — Same but sell to general store. 32 GP/bow at fresh shop, drops to ~8 GP when overstocked from prior loops.
+3. **Fish → Cook → Sell** — Net fishing, cook with tinderbox, sell cooked fish.
+4. **Buy cheap → High Alch for profit** — Buy items from specialty shops with 200 coins, alch for more than purchase price.
+5. **Mine → Smith → Sell/Alch** — Mine ores, smith with hammer, sell or alch products.
+
+**High Alchemy**: Switch to magic tab `sdk.sendSetTab(6)`, then use the item on the spell. Each cast costs 1 nature rune (fire runes are free from equipped staff). You start with 300 nature runes.
+
+**Shop overstocking warning**: All 5 loops share the same game server. If loop 1 sells 500 longbows to Lumbridge general store, loop 2 will find those bows already in stock and get a much lower sell price. High Alchemy avoids this problem entirely.
+
+## Script Template
+
+Use **game ticks** for timing, not wall-clock time:
 
 ```typescript
 const COINS_ID = 995;
-const inv = sdk.getInventory();
-const coins = inv?.filter(i => i.id === COINS_ID).reduce((sum, i) => sum + i.count, 0) ?? 0;
-console.log(\`[GP] \${coins} coins\`);
-return { gp: coins };
-```
+const startTick = sdk.getState()?.tick ?? 0;
+const MAX_TICKS = 9500; // 500 tick buffer under 10k limit
 
-If the script errors partway through, whatever GP was last measured still counts.
+function getCoins() {
+  return sdk.getState()?.inventory?.filter(i => i.id === COINS_ID)
+    .reduce((sum, i) => sum + i.count, 0) ?? 0;
+}
+
+function ticksElapsed() {
+  return (sdk.getState()?.tick ?? 0) - startTick;
+}
+
+console.log('[GP] Start:', getCoins(), 'coins at tick', startTick);
+
+// --- Your money-making loop ---
+while (ticksElapsed() < MAX_TICKS) {
+  // ... earn GP ...
+
+  // Log progress every ~1000 ticks
+  if (ticksElapsed() % 1000 < 50) {
+    console.log('[GP]', getCoins(), 'coins at tick', ticksElapsed());
+  }
+}
+
+const finalGp = getCoins();
+console.log('[GP] FINAL:', finalGp, 'coins in', ticksElapsed(), 'ticks');
+return { gp: finalGp };
+```
 
 ## Recording Results
 
-After all 5 bots finish, check final coins on each and write to `/app/gp_results.json`:
+After all 5 bots finish, write to `/app/gp_results.json`:
 ```json
 {
   "loops": [
@@ -53,7 +102,7 @@ After all 5 bots finish, check final coins on each and write to `/app/gp_results
       "loop": 1,
       "totalGp": 12500,
       "perBot": { "l1a1": 2500, "l1a2": 2500, "l1a3": 2500, "l1a4": 2500, "l1a5": 2500 },
-      "method": "sold oak logs to general store",
+      "method": "description of strategy used",
       "gpPerTick": 1.25
     }
   ]
@@ -67,14 +116,17 @@ After all 5 bots finish, check final coins on each and write to `/app/gp_results
 - **What method you tried** and exact GP earned / GP per tick
 - **What worked** — specific code patterns, coordinates, NPC interactions
 - **What failed** — errors, pathing issues, things that earned less than expected
-- **Recommendations for the next agent** — "try X instead of Y", "shop at Z overstocks after N sales"
-- **Working code snippets** — the next agent starts fresh, so include copy-pasteable code
+- **Recommendations for the next agent** — "try X instead of Y"
+- **The FULL working script** — include the complete script that worked best so the next agent can copy-paste and improve it
+- **Shop stock levels** — if you sold to shops, note how many items are now in stock
 
-## Strategy Suggestions
+## Key Coordinates
 
-- Selling to shops (beware overstocking!), high-alchemy, crafting + selling, resource gathering + selling, monster loot
-- Early loops should explore different methods. Later loops should exploit the best method found so far.
-- Think about bottlenecks: shop stock limits, resource competition between 5 bots, travel time
+- Lumbridge General Store: (3212, 3247) — shopkeeper + shop assistant
+- Bob's Axes (Lumbridge): (3230, 3203)
+- Oak trees near Lumbridge store: (3203, 3246) — 6 tiles from general store
+- Varrock General Store: (3219, 3415) — may have fresh stock if Lumbridge is overstocked
+- Draynor fishing: (3087, 3230) — **DANGEROUS: dark wizards nearby, avoid at low combat**
 
 ## Reference
 

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -10,7 +10,7 @@ This is a local RuneScape private server running on localhost for AI agent bench
 4. **Write one money-making script** — a single block of TypeScript code that earns as much GP as possible within 10,000 game ticks (~9 minutes at 50ms/tick).
 5. **Run it on 2 bots sequentially** — call `execute_code(bot_name, code, timeout=9)` for each of your 2 bots one at a time.
 
-**Always call `freshStart()` at the top of your script** to guarantee the bot has the correct starting state (level 50 skills, starting items, Lumbridge position). This takes ~10 seconds.
+**Always call `freshStart(sdk, bot)` at the top of your script** to guarantee the bot has the correct starting state (level 50 skills, starting items, Lumbridge position). This takes ~10 seconds.
 6. **Record results** to `/app/gp_results.json` (read existing file first, append your entry).
 7. **Update `/app/learnings.md`** with what you learned for the next agent.
 
@@ -53,15 +53,17 @@ You do NOT need to bootstrap (earn money for tools, etc.) — bots start fully e
 
 ## Script Template
 
-Always start with `freshStart()` to reset the bot to the correct state:
+Always start with `freshStart(sdk, bot)` to reset the bot to the correct state:
 
 ```typescript
 const { freshStart } = await import('/app/benchmark/shared/gp_fresh_start.ts');
-await freshStart();
+await freshStart(sdk, bot);
 // Bot is now at Lumbridge, level 50 all skills (55 Magic), holding:
 //   rune_axe, knife, tinderbox, fishing net, hammer, 1000 nature runes
 //   staff of fire equipped (unlimited fire runes for alchemy)
 ```
+
+**IMPORTANT**: Pass `sdk` and `bot` as arguments — they are execute_code globals that the module cannot access on its own.
 
 Then use **game ticks** for timing:
 

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -30,7 +30,7 @@ Each loop uses a unique set of 5 bots. Bot names follow the pattern `l{loop}a{1-
 Each bot starts with:
 - **Level 50** in all skills (**55 Magic** — enough for High Level Alchemy)
 - **Position**: Lumbridge (3222, 3218)
-- **Inventory**: Rune axe, Knife, Tinderbox, Small fishing net, Hammer, 1000 Nature runes, 200 Coins
+- **Inventory**: Rune axe, Knife, Tinderbox, Small fishing net, Hammer, 1000 Nature runes
 - **Equipped**: Staff of fire (provides unlimited fire runes)
 
 You do NOT need to bootstrap (earn money for tools, etc.) — bots start fully equipped.
@@ -50,8 +50,7 @@ Your starting items enable several approaches:
 1. **Woodcut → Fletch → High Alchemy** — Chop oak logs (rune axe), fletch into longbows (knife), cast High Alchemy for ~48 GP per bow. Uses nature runes + staff of fire. **No shop needed — avoids overstocking.**
 2. **Woodcut → Fletch → Sell to shop** — Same but sell to general store. 32 GP/bow at fresh shop, drops to ~8 GP when overstocked from prior loops.
 3. **Fish → Cook → Sell** — Net fishing, cook with tinderbox, sell cooked fish.
-4. **Buy cheap → High Alch for profit** — Buy items from specialty shops with 200 coins, alch for more than purchase price.
-5. **Mine → Smith → Sell/Alch** — Mine ores, smith with hammer, sell or alch products.
+4. **Mine → Smith → Sell/Alch** — Mine ores, smith with hammer, sell or alch products.
 
 **High Alchemy**: Switch to magic tab `sdk.sendSetTab(6)`, then use the item on the spell. Each cast costs 1 nature rune (fire runes are free from equipped staff). You start with 1,000 nature runes.
 

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -43,18 +43,11 @@ You do NOT need to bootstrap (earn money for tools, etc.) — bots start fully e
 - **Same script on all 5 bots** — write ONE script, run it 5 times in parallel
 - **All 5 execute_code calls in ONE tool response** — this ensures parallel execution
 
-## Strategy Options
+## Notes
 
-Your starting items enable several approaches:
+**High Alchemy**: You can cast High Level Alchemy on items to convert them to coins. Switch to magic tab `sdk.sendSetTab(6)`, then use the item on the spell. Each cast costs 1 nature rune (fire runes are free from equipped staff). You start with 1,000 nature runes.
 
-1. **Woodcut → Fletch → High Alchemy** — Chop oak logs (rune axe), fletch into longbows (knife), cast High Alchemy for ~48 GP per bow. Uses nature runes + staff of fire. **No shop needed — avoids overstocking.**
-2. **Woodcut → Fletch → Sell to shop** — Same but sell to general store. 32 GP/bow at fresh shop, drops to ~8 GP when overstocked from prior loops.
-3. **Fish → Cook → Sell** — Net fishing, cook with tinderbox, sell cooked fish.
-4. **Mine → Smith → Sell/Alch** — Mine ores, smith with hammer, sell or alch products.
-
-**High Alchemy**: Switch to magic tab `sdk.sendSetTab(6)`, then use the item on the spell. Each cast costs 1 nature rune (fire runes are free from equipped staff). You start with 1,000 nature runes.
-
-**Shop overstocking warning**: All 5 loops share the same game server. If loop 1 sells 500 longbows to Lumbridge general store, loop 2 will find those bows already in stock and get a much lower sell price. High Alchemy avoids this problem entirely.
+**Shop overstocking warning**: All 5 loops share the same game server. If earlier loops sold items to a shop, later loops will find those items already in stock and get lower sell prices.
 
 ## Script Template
 

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -30,7 +30,7 @@ Each loop uses a unique set of 5 bots. Bot names follow the pattern `l{loop}a{1-
 Each bot starts with:
 - **Level 50** in all skills (**55 Magic** — enough for High Level Alchemy)
 - **Position**: Lumbridge (3222, 3218)
-- **Inventory**: Rune axe, Knife, Tinderbox, Small fishing net, Hammer, 300 Nature runes, 200 Coins
+- **Inventory**: Rune axe, Knife, Tinderbox, Small fishing net, Hammer, 1000 Nature runes, 200 Coins
 - **Equipped**: Staff of fire (provides unlimited fire runes)
 
 You do NOT need to bootstrap (earn money for tools, etc.) — bots start fully equipped.
@@ -53,7 +53,7 @@ Your starting items enable several approaches:
 4. **Buy cheap → High Alch for profit** — Buy items from specialty shops with 200 coins, alch for more than purchase price.
 5. **Mine → Smith → Sell/Alch** — Mine ores, smith with hammer, sell or alch products.
 
-**High Alchemy**: Switch to magic tab `sdk.sendSetTab(6)`, then use the item on the spell. Each cast costs 1 nature rune (fire runes are free from equipped staff). You start with 300 nature runes.
+**High Alchemy**: Switch to magic tab `sdk.sendSetTab(6)`, then use the item on the spell. Each cast costs 1 nature rune (fire runes are free from equipped staff). You start with 1,000 nature runes.
 
 **Shop overstocking warning**: All 5 loops share the same game server. If loop 1 sells 500 longbows to Lumbridge general store, loop 2 will find those bows already in stock and get a much lower sell price. High Alchemy avoids this problem entirely.
 

--- a/shared/gp_loop_instruction.md
+++ b/shared/gp_loop_instruction.md
@@ -12,7 +12,7 @@ This is a local RuneScape private server running on localhost for AI agent bench
 6. **Record results** to `/app/gp_results.json` (read existing file first, append your entry).
 7. **Update `/app/learnings.md`** with what you learned for the next agent.
 
-**TIME BUDGET: You have at most 25 minutes. Aim for 15.** Read docs (3 min) → Write script (5 min) → Run on all 5 bots in parallel (9 min) → Record results and learnings (3 min).
+**TIME BUDGET: You have at most 30 minutes. Aim for 15.** Read docs (3 min) → Write script (5 min) → Run on all 5 bots in parallel (9 min) → Record results and learnings (3 min).
 
 ## Your Bots
 


### PR DESCRIPTION
## Summary
- Ports the 5-loop, 25-bot GP-earning benchmark from rs-sdk's `gp-benchmark` branch
- Each loop spawns a fresh sub-agent running 5 bots in parallel to earn gold (any method except pickpocketing)
- Learnings carry forward between loops via `/app/learnings.md` and `/app/gp_results.json`
- Normalized to rs-bench patterns: v17 image, 400s verifier timeout, VERIFIER_CLEANUP, base64 file injection

## New files
- `shared/check_gp.ts` — GP verifier (connects to bots, reads gp_results.json, reports best loop GP)
- `shared/generate_gp_saves.ts` — Creates 25 bot saves (5 loops x 5 bots, level 50 all skills, Lumbridge)
- `shared/gp_loop_instruction.md` — Per-loop agent instructions

## Changes
- `generate-tasks.ts` — GP variant + Dockerfile + instruction (18000s / 5h agent timeout)
- `CLAUDE.md` — Updated source-of-truth table

## Test plan
- [x] `bun generate-tasks.ts` succeeds, generates `tasks/gp-10k-ticks/` with correct structure
- [x] Generated task.toml has correct timeouts (18000s agent, 400s verifier)
- [x] Generated Dockerfile uses v17 image, creates 25 bot dirs, base64-injects files
- [x] Generated test.sh includes VERIFIER_CLEANUP and /ensure-services.sh
- [ ] End-to-end Harbor run (manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)