### PR TITLE
Add share links to trajectory steps

### DIFF
--- a/app/components/TrajectoryModal.js
+++ b/app/components/TrajectoryModal.js
@@ -30,6 +30,35 @@ function formatTimestamp(seconds) {
   return m + ':' + String(s).padStart(2, '0');
 }
 
+function trajectoryUrl(model, skill, seconds) {
+  const base = window.location.href.split('#')[0];
+  const ts = seconds == null || isNaN(seconds) ? '' : '@' + Math.round(seconds);
+  return base + '#/trajectory/' + model + '/' + skill + ts;
+}
+
+async function copyText(text) {
+  let clipboardError = null;
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch (err) {
+      clipboardError = err;
+    }
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand('copy');
+  document.body.removeChild(textarea);
+  if (!copied) throw clipboardError || new Error('Copy command was not accepted');
+}
+
 function findSkillLevel(sample, skillKey) {
   if (!sample?.skills) return 1;
   const skillName = SKILL_DISPLAY[skillKey] || skillKey;
@@ -261,6 +290,7 @@ export function TrajectoryModal({ model, skill, data, seekTs }) {
   }, [data, model, skill, modelsForSkill, skillsForModel]);
 
   const [videoOffset, setVideoOffset] = useState(0);
+  const [copiedTs, setCopiedTs] = useState(null);
 
   const containerRef = useRef(null);
   const videoRef = useRef(null);
@@ -321,12 +351,29 @@ export function TrajectoryModal({ model, skill, data, seekTs }) {
   const handleStepClick = useCallback((e) => {
     if (e.target.closest('.traj-tool-code')) return;
     if (e.target.closest('.traj-tool-detail-header')) return;
+    if (e.target.closest('[data-copy-ts]')) return;
     const target = e.target.closest('[data-ts]');
     if (!target) return;
     const ts = parseFloat(target.dataset.ts);
     if (isNaN(ts)) return;
     seekVideo(ts);
   }, [seekVideo]);
+
+  const handleCopyLink = useCallback(async (e) => {
+    const target = e.target.closest('[data-copy-ts]');
+    if (!target) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const ts = parseFloat(target.dataset.copyTs);
+    const copyKey = Math.round(ts);
+    try {
+      await copyText(trajectoryUrl(model, skill, ts));
+      setCopiedTs(copyKey);
+      window.setTimeout(() => setCopiedTs(curr => curr === copyKey ? null : curr), 1400);
+    } catch (err) {
+      console.warn('Could not copy trajectory link', err);
+    }
+  }, [model, skill]);
 
   // Handle hover on transcript step → show ghost playhead on charts
   const handleStepHover = useCallback((e) => {
@@ -976,6 +1023,14 @@ export function TrajectoryModal({ model, skill, data, seekTs }) {
                         <div key=${i} className="traj-step agent" data-ts=${step.ts != null ? String(step.ts) : undefined}>
                           ${step.ts != null && html`
                             <span className="traj-timestamp">${formatTimestamp(step.ts)}</span>
+                            <button
+                              type="button"
+                              className="traj-copy-link"
+                              title="Copy link to this moment"
+                              aria-label="Copy link to this moment"
+                              data-copy-ts=${String(step.ts)}
+                              onClick=${handleCopyLink}
+                            >${copiedTs === Math.round(step.ts) ? 'copied' : 'link'}</button>
                           `}
                           ${step.text}
                         </div>
@@ -984,6 +1039,16 @@ export function TrajectoryModal({ model, skill, data, seekTs }) {
                     if (step.type === 'tool-group') {
                       return html`
                         <div key=${i} className="traj-tool-group" data-ts=${step.ts != null ? String(step.ts) : undefined}>
+                          ${step.ts != null && html`
+                            <button
+                              type="button"
+                              className="traj-copy-link"
+                              title="Copy link to this moment"
+                              aria-label="Copy link to this moment"
+                              data-copy-ts=${String(step.ts)}
+                              onClick=${handleCopyLink}
+                            >${copiedTs === Math.round(step.ts) ? 'copied' : 'link'}</button>
+                          `}
                           ${step.tools.map((t, j) => html`
                             <span key=${j} className="traj-tool-chip">${t}</span>
                           `)}
@@ -992,7 +1057,17 @@ export function TrajectoryModal({ model, skill, data, seekTs }) {
                     }
                     if (step.type === 'tool-detail') {
                       return html`
-                        <div key=${i} data-ts=${step.ts != null ? String(step.ts) : undefined}>
+                        <div key=${i} className="traj-tool-detail-row" data-ts=${step.ts != null ? String(step.ts) : undefined}>
+                          ${step.ts != null && html`
+                            <button
+                              type="button"
+                              className="traj-copy-link"
+                              title="Copy link to this moment"
+                              aria-label="Copy link to this moment"
+                              data-copy-ts=${String(step.ts)}
+                              onClick=${handleCopyLink}
+                            >${copiedTs === Math.round(step.ts) ? 'copied' : 'link'}</button>
+                          `}
                           <${ToolDetail} label=${step.label} detail=${step.detail} />
                         </div>
                       `;

--- a/app/styles.css
+++ b/app/styles.css
@@ -765,6 +765,31 @@ body {
   background: #e0e0e0;
   color: #555;
 }
+.traj-copy-link {
+  display: inline-block;
+  margin-right: 6px;
+  padding: 1px 5px;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  background: #fff;
+  color: #888;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 1.5;
+  cursor: pointer;
+  vertical-align: middle;
+}
+.traj-copy-link:hover {
+  border-color: #bbb;
+  color: #555;
+  background: #f8f8f8;
+}
+.traj-tool-detail-row {
+  cursor: pointer;
+}
+.traj-tool-detail-row .traj-copy-link {
+  margin-top: 4px;
+}
 
 /* Sortable column headers */
 .sort-header {


### PR DESCRIPTION
## Summary

- Add a small `link` button next to timestamped trajectory transcript entries.
- Copy a deep link to that exact moment, reusing the existing `#/trajectory/<model>/<skill>@<seconds>` route format.
- Show a brief `copied` confirmation after the clipboard write succeeds.

## Test plan

- `node --check app/components/TrajectoryModal.js`
- `node --check app/router.js`
- `git diff --check HEAD~1..HEAD`
- End-to-end browser test against a local static server:
  - opened `#/trajectory/geminiflash/fishing`
  - clicked the new transcript `link` button with real Chrome mouse input
  - verified the clipboard contained `#/trajectory/geminiflash/fishing@4`
  - navigated to the copied URL
  - verified the matching transcript entry became active

## Visual evidence

Captured during the local e2e run:

- `trajectory-copy-link-copied.png` — shows the new button after it changes to `copied`.
- `trajectory-deeplink-active.png` — shows the copied deep link reopened with the target transcript entry active.
